### PR TITLE
Add test for preserving existing duplicates with _dNNNN suffix in ini…

### DIFF
--- a/main.go
+++ b/main.go
@@ -598,8 +598,12 @@ func isValidArchivedPath(relPath string) bool {
 // isExistingDuplicateFile reports whether a file already inside _duplicates is a genuine
 // duplicate of a file that exists in the main archive. relPath is relative to absOutput.
 // It returns true when the relative path within _duplicates is a valid archived structure
-// and the corresponding original file (with any _NN collision suffix removed) is present
+// and the corresponding original file (with any collision suffix removed) is present
 // in the main archive, so the file should be registered in place rather than re-moved.
+//
+// Two collision suffix formats are recognised:
+//   - _dNNNN  (underscore + 'd' + one or more digits, e.g. _d0001)
+//   - _NN     (exactly underscore + two digits, e.g. _01)
 func isExistingDuplicateFile(relPath string, absOutput string) bool {
 	dupPrefix := "_duplicates" + string(filepath.Separator)
 	if !strings.HasPrefix(relPath, dupPrefix) {
@@ -616,9 +620,26 @@ func isExistingDuplicateFile(relPath string, absOutput string) bool {
 	fileExt := filepath.Ext(filename)
 	baseName := strings.TrimSuffix(filename, fileExt)
 
-	// Strip a _NN collision suffix (exactly underscore + two digits) if present.
+	// Strip a collision suffix if present.
 	originalBase := baseName
-	if len(baseName) >= 3 {
+
+	// Try _dNNNN format first (e.g. _d0001, _d0042).
+	if idx := strings.LastIndex(baseName, "_d"); idx >= 0 && idx < len(baseName)-2 {
+		rest := baseName[idx+2:]
+		allDigits := true
+		for _, c := range rest {
+			if c < '0' || c > '9' {
+				allDigits = false
+				break
+			}
+		}
+		if allDigits {
+			originalBase = baseName[:idx]
+		}
+	}
+
+	// Fall back to _NN format (exactly underscore + two digits, e.g. _01).
+	if originalBase == baseName && len(baseName) >= 3 {
 		s := baseName[len(baseName)-3:]
 		if s[0] == '_' && s[1] >= '0' && s[1] <= '9' && s[2] >= '0' && s[2] <= '9' {
 			originalBase = baseName[:len(baseName)-3]

--- a/main_test.go
+++ b/main_test.go
@@ -669,6 +669,55 @@ func TestInitModePreservesExistingDuplicates(t *testing.T) {
 	t.Logf("Existing duplicates correctly preserved in _duplicates")
 }
 
+// TestInitModePreservesExistingDuplicatesWithDSuffix verifies that files in _duplicates
+// that use the _dNNNN suffix format (e.g. report_d0001.pdf) are recognised as genuine
+// duplicates of the corresponding main-archive file and are NOT moved.
+func TestInitModePreservesExistingDuplicatesWithDSuffix(t *testing.T) {
+	bin := buildBinary(t)
+	work := t.TempDir()
+	dst := filepath.Join(work, "dst")
+
+	mt := time.Date(2023, 1, 2, 10, 0, 0, 0, time.Local)
+
+	// Main archive file.
+	originalPath := filepath.Join(dst, "crm", "2023", "01", "02", "20221231 - NewYear2022 - part 45.CRM")
+	if err := os.MkdirAll(filepath.Dir(originalPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(originalPath, []byte("original"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(originalPath, mt, mt); err != nil {
+		t.Fatal(err)
+	}
+
+	// Duplicate with _d0001 suffix already sitting inside _duplicates.
+	dupPath := filepath.Join(dst, "_duplicates", "crm", "2023", "01", "02", "20221231 - NewYear2022 - part 45_d0001.CRM")
+	if err := os.MkdirAll(filepath.Dir(dupPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dupPath, []byte("duplicate"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(dupPath, mt, mt); err != nil {
+		t.Fatal(err)
+	}
+
+	runBinary(t, bin, work, "-init", "-output", dst)
+
+	// Original must stay put.
+	if _, err := os.Stat(originalPath); err != nil {
+		t.Fatalf("expected original to remain at %s: %v", originalPath, err)
+	}
+
+	// Duplicate must remain in _duplicates — not moved elsewhere.
+	if _, err := os.Stat(dupPath); err != nil {
+		t.Fatalf("expected _d0001 duplicate to remain at %s: %v", dupPath, err)
+	}
+
+	t.Logf("_d#### duplicate correctly preserved in _duplicates")
+}
+
 func TestInitModeHonorsIgnoreFile(t *testing.T) {
 	bin := buildBinary(t)
 	work := t.TempDir()


### PR DESCRIPTION
…t mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced duplicate file collision detection to recognise multiple naming conventions, improving the reliability of file identification and preservation during the initialisation process.

* **Tests**
  * Added comprehensive test coverage for the enhanced duplicate file detection, validating compatibility with different naming patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->