### PR TITLE
Add trash/recycle bin, Manage tab, and file action audit log

### DIFF
--- a/internal/api/duplicates.go
+++ b/internal/api/duplicates.go
@@ -2,9 +2,11 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"filearchiver/internal/db"
 )
@@ -24,8 +26,8 @@ func handleListDuplicates(cfg Config) http.HandlerFunc {
 	}
 }
 
-// handleDeleteFile deletes a file from disk and removes its registry record.
-// A confirm=true query param is required as a double-submit CSRF guard.
+// handleDeleteFile moves a file to the _trash directory and marks it as trashed
+// in the registry. A confirm=true query param is required as a safety guard.
 func handleDeleteFile(cfg Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("confirm") != "true" {
@@ -56,18 +58,33 @@ func handleDeleteFile(cfg Config) http.HandlerFunc {
 			return
 		}
 
-		// Delete from disk — tolerate already-missing files.
-		if err := os.Remove(absPath); err != nil && !os.IsNotExist(err) {
-			writeError(w, http.StatusInternalServerError, "cannot delete file: "+err.Error())
+		// Resolve a safe destination inside _trash/.
+		trashDir := filepath.Join(absRoot, "_trash")
+		if err := os.MkdirAll(trashDir, 0755); err != nil {
+			writeError(w, http.StatusInternalServerError, "cannot create trash directory: "+err.Error())
 			return
 		}
-
-		if err := db.DeleteFileRecord(cfg.DB, id); err != nil {
+		trashPath, err := resolveTrashPath(trashDir, file.FileName)
+		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 
-		writeJSON(w, http.StatusOK, map[string]any{"deleted": id})
+		// Move file into trash (tolerate already-missing files).
+		if err := os.Rename(absPath, trashPath); err != nil && !os.IsNotExist(err) {
+			writeError(w, http.StatusInternalServerError, "cannot move file to trash: "+err.Error())
+			return
+		}
+
+		if err := db.TrashFile(cfg.DB, id, trashPath); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		_ = db.LogFileAction(cfg.DB, &id, file.FileName, file.ArchivePath,
+			"trashed", "moved to _trash/ via web UI")
+
+		writeJSON(w, http.StatusOK, map[string]any{"trashed": id, "trash_path": trashPath})
 	}
 }
 
@@ -236,4 +253,22 @@ func purgeThumbs(thumbDir string) error {
 		_ = os.Remove(m)
 	}
 	return nil
+}
+
+// resolveTrashPath returns a unique destination path inside trashDir for the
+// given filename. If the base name already exists it appends _01.._99.
+func resolveTrashPath(trashDir, fileName string) (string, error) {
+	base := filepath.Join(trashDir, fileName)
+	if _, err := os.Stat(base); os.IsNotExist(err) {
+		return base, nil
+	}
+	ext := filepath.Ext(fileName)
+	stem := strings.TrimSuffix(fileName, ext)
+	for i := 1; i <= 99; i++ {
+		candidate := filepath.Join(trashDir, fmt.Sprintf("%s_%02d%s", stem, i, ext))
+		if _, err := os.Stat(candidate); os.IsNotExist(err) {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("too many files named %q in trash", fileName)
 }

--- a/internal/api/media.go
+++ b/internal/api/media.go
@@ -93,7 +93,7 @@ func handleGetFileHistory(cfg Config) http.HandlerFunc {
 			return
 		}
 
-		entries, err := db.GetHistoryForFile(cfg.DB, file.ArchivePath)
+		entries, err := db.GetHistoryForFile(cfg.DB, file.ID, file.ArchivePath)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -54,6 +54,17 @@ func NewRouter(cfg Config) http.Handler {
 			r.Post("/{id}/promote", readonlyGuard(cfg, handlePromoteDuplicate(cfg)))
 		})
 
+		r.Route("/trash", func(r chi.Router) {
+			r.Get("/", handleListTrash(cfg))
+			r.Delete("/", readonlyGuard(cfg, handleEmptyTrash(cfg)))
+			r.Post("/{id}/restore", readonlyGuard(cfg, handleRestoreTrash(cfg)))
+			r.Delete("/{id}", readonlyGuard(cfg, handlePermanentlyDeleteTrash(cfg)))
+		})
+
+		r.Route("/file-actions", func(r chi.Router) {
+			r.Get("/", handleListFileActions(cfg))
+		})
+
 		r.Route("/history", func(r chi.Router) {
 			r.Get("/", handleListHistory(cfg))
 			r.Get("/recent", handleGetRecentHistory(cfg))

--- a/internal/api/trash.go
+++ b/internal/api/trash.go
@@ -1,0 +1,205 @@
+package api
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"filearchiver/internal/db"
+	"github.com/go-chi/chi/v5"
+)
+
+// handleListTrash returns all files currently in the trash.
+func handleListTrash(cfg Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		files, err := db.ListTrashedFiles(cfg.DB)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if files == nil {
+			files = []db.File{}
+		}
+		writeJSON(w, http.StatusOK, files)
+	}
+}
+
+// handleRestoreTrash moves a trashed file back to its original archive location.
+func handleRestoreTrash(cfg Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid file id")
+			return
+		}
+
+		file, err := db.GetFile(cfg.DB, id)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if file == nil || file.TrashedAt == nil {
+			writeError(w, http.StatusNotFound, "trashed file not found")
+			return
+		}
+
+		absRoot, _ := filepath.Abs(cfg.ArchiveRoot)
+		absSrc, _ := filepath.Abs(file.ArchivePath) // current trash path
+
+		if !isUnderRoot(absSrc, absRoot) {
+			writeError(w, http.StatusForbidden, "path outside archive root")
+			return
+		}
+
+		// RestoreFileRecord updates the DB and returns the original archive path.
+		restorePath, err := db.RestoreFileRecord(cfg.DB, id)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		absDst, _ := filepath.Abs(restorePath)
+		if !isUnderRoot(absDst, absRoot) {
+			// Roll back DB if path is suspect.
+			_ = db.TrashFile(cfg.DB, id, file.ArchivePath)
+			writeError(w, http.StatusForbidden, "restore path outside archive root")
+			return
+		}
+
+		if err := os.MkdirAll(filepath.Dir(absDst), 0755); err != nil {
+			writeError(w, http.StatusInternalServerError, "cannot create restore directory: "+err.Error())
+			return
+		}
+
+		if err := os.Rename(absSrc, absDst); err != nil {
+			writeError(w, http.StatusInternalServerError, "cannot restore file: "+err.Error())
+			return
+		}
+
+		_ = db.LogFileAction(cfg.DB, &id, file.FileName, restorePath,
+			"restored", "restored from _trash/ via web UI")
+
+		updated, _ := db.GetFile(cfg.DB, id)
+		writeJSON(w, http.StatusOK, updated)
+	}
+}
+
+// handlePermanentlyDeleteTrash permanently removes a single trashed file from
+// disk and its registry record. Requires confirm=true.
+func handlePermanentlyDeleteTrash(cfg Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("confirm") != "true" {
+			writeError(w, http.StatusBadRequest, "confirm=true is required")
+			return
+		}
+		id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid file id")
+			return
+		}
+
+		file, err := db.GetFile(cfg.DB, id)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if file == nil || file.TrashedAt == nil {
+			writeError(w, http.StatusNotFound, "trashed file not found")
+			return
+		}
+
+		absPath, _ := filepath.Abs(file.ArchivePath)
+		absRoot, _ := filepath.Abs(cfg.ArchiveRoot)
+		if !isUnderRoot(absPath, absRoot) {
+			writeError(w, http.StatusForbidden, "path outside archive root")
+			return
+		}
+
+		// Log before deleting the registry record (so file_id FK is still valid).
+		_ = db.LogFileAction(cfg.DB, &id, file.FileName, file.ArchivePath,
+			"permanently_deleted", "permanently deleted from _trash/ via web UI")
+
+		if err := os.Remove(absPath); err != nil && !os.IsNotExist(err) {
+			writeError(w, http.StatusInternalServerError, "cannot delete file: "+err.Error())
+			return
+		}
+
+		if err := db.DeleteFileRecord(cfg.DB, id); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{"permanently_deleted": id})
+	}
+}
+
+// handleEmptyTrash permanently deletes ALL trashed files. Requires confirm=true.
+func handleEmptyTrash(cfg Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("confirm") != "true" {
+			writeError(w, http.StatusBadRequest, "confirm=true is required")
+			return
+		}
+
+		files, err := db.ListTrashedFiles(cfg.DB)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		absRoot, _ := filepath.Abs(cfg.ArchiveRoot)
+		deleted := 0
+		var errs []string
+
+		for _, f := range files {
+			absPath, _ := filepath.Abs(f.ArchivePath)
+			if !isUnderRoot(absPath, absRoot) {
+				continue
+			}
+
+			fID := f.ID
+			_ = db.LogFileAction(cfg.DB, &fID, f.FileName, f.ArchivePath,
+				"permanently_deleted", "permanently deleted via empty trash")
+
+			if err := os.Remove(absPath); err != nil && !os.IsNotExist(err) {
+				errs = append(errs, f.FileName+": "+err.Error())
+				continue
+			}
+			if err := db.DeleteFileRecord(cfg.DB, f.ID); err != nil {
+				errs = append(errs, f.FileName+": "+err.Error())
+				continue
+			}
+			deleted++
+		}
+
+		resp := map[string]any{"deleted": deleted}
+		if len(errs) > 0 {
+			resp["errors"] = errs
+		}
+		writeJSON(w, http.StatusOK, resp)
+	}
+}
+
+// handleListFileActions returns the paginated file_actions audit log.
+func handleListFileActions(cfg Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		page, _ := strconv.Atoi(q.Get("page"))
+		perPage, _ := strconv.Atoi(q.Get("per_page"))
+
+		result, err := db.ListAllFileActions(cfg.DB, db.FileActionListParams{
+			Action:  q.Get("action"),
+			Search:  q.Get("q"),
+			From:    q.Get("from"),
+			To:      q.Get("to"),
+			Page:    page,
+			PerPage: perPage,
+		})
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, result)
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -3,6 +3,7 @@ package db
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 
 	_ "modernc.org/sqlite"
 )
@@ -71,6 +72,23 @@ func Migrate(database *sql.DB) error {
 		`CREATE INDEX IF NOT EXISTS idx_file_tags_file ON file_tags(file_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_file_tags_tag  ON file_tags(tag_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_registry_path  ON file_registry(archive_path)`,
+
+		// Audit log: records every trash/restore/permanent-delete action on a
+		// file. file_id is set to NULL when the registry record is removed so
+		// the history survives the file's deletion.
+		`CREATE TABLE IF NOT EXISTS file_actions (
+			id           INTEGER PRIMARY KEY AUTOINCREMENT,
+			file_id      INTEGER REFERENCES file_registry(id) ON DELETE SET NULL,
+			file_name    TEXT    NOT NULL,
+			archive_path TEXT    NOT NULL,
+			action       TEXT    NOT NULL,
+			performed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			notes        TEXT
+		)`,
+
+		`CREATE INDEX IF NOT EXISTS idx_file_actions_file   ON file_actions(file_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_file_actions_action ON file_actions(action)`,
+		`CREATE INDEX IF NOT EXISTS idx_file_actions_time   ON file_actions(performed_at)`,
 	}
 
 	for _, stmt := range stmts {
@@ -78,5 +96,34 @@ func Migrate(database *sql.DB) error {
 			return fmt.Errorf("migration failed: %w", err)
 		}
 	}
+
+	// Add trash columns to file_registry if they don't exist yet.
+	// SQLite does not support IF NOT EXISTS on ALTER TABLE, so we attempt each
+	// and ignore "duplicate column name" errors.
+	trashCols := []string{
+		`ALTER TABLE file_registry ADD COLUMN trashed_at   DATETIME DEFAULT NULL`,
+		`ALTER TABLE file_registry ADD COLUMN trash_path   TEXT     DEFAULT NULL`,
+		`ALTER TABLE file_registry ADD COLUMN restore_path TEXT     DEFAULT NULL`,
+	}
+	for _, stmt := range trashCols {
+		if _, err := database.Exec(stmt); err != nil {
+			// "duplicate column name" means the column already exists — safe to skip.
+			if !isDuplicateColumn(err) {
+				return fmt.Errorf("migration failed: %w", err)
+			}
+		}
+	}
+
+	if _, err := database.Exec(
+		`CREATE INDEX IF NOT EXISTS idx_registry_trashed ON file_registry(trashed_at)`,
+	); err != nil {
+		return fmt.Errorf("migration failed: %w", err)
+	}
+
 	return nil
+}
+
+// isDuplicateColumn reports whether err is a SQLite "duplicate column name" error.
+func isDuplicateColumn(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "duplicate column name")
 }

--- a/internal/db/duplicates.go
+++ b/internal/db/duplicates.go
@@ -22,6 +22,7 @@ func GetDuplicateGroups(database *sql.DB) ([]DuplicateGroup, error) {
 	rows, err := database.Query(`
 		SELECT id, original_path, archive_path, file_name, size, checksum, mod_time
 		FROM file_registry
+		WHERE trashed_at IS NULL
 		ORDER BY file_name, archive_path
 	`)
 	if err != nil {

--- a/internal/db/files.go
+++ b/internal/db/files.go
@@ -10,15 +10,18 @@ import (
 
 // File is a row from file_registry with derived fields.
 type File struct {
-	ID           int64     `json:"id"`
-	OriginalPath string    `json:"original_path"`
-	ArchivePath  string    `json:"archive_path"`
-	FileName     string    `json:"file_name"`
-	Size         int64     `json:"size"`
-	Checksum     string    `json:"checksum"`
-	ModTime      time.Time `json:"mod_time"`
-	Extension    string    `json:"extension"`
-	IsDuplicate  bool      `json:"is_duplicate"`
+	ID           int64      `json:"id"`
+	OriginalPath string     `json:"original_path"`
+	ArchivePath  string     `json:"archive_path"`
+	FileName     string     `json:"file_name"`
+	Size         int64      `json:"size"`
+	Checksum     string     `json:"checksum"`
+	ModTime      time.Time  `json:"mod_time"`
+	Extension    string     `json:"extension"`
+	IsDuplicate  bool       `json:"is_duplicate"`
+	// Trash fields — only populated for trashed files.
+	TrashedAt   *time.Time `json:"trashed_at,omitempty"`
+	RestorePath string     `json:"restore_path,omitempty"`
 }
 
 // FileListParams holds filter/sort/pagination options for ListFiles.
@@ -189,6 +192,9 @@ func buildWhereClause(p FileListParams) (string, []interface{}) {
 		conditions = append(conditions, `fr.archive_path LIKE '%/_duplicates/%'`)
 	}
 
+	// Always exclude trashed files from the regular file list.
+	conditions = append(conditions, `fr.trashed_at IS NULL`)
+
 	joinClause := ""
 	if p.TagName != "" {
 		joinClause = `JOIN file_tags ft ON ft.file_id = fr.id JOIN tags t ON t.id = ft.tag_id`
@@ -210,6 +216,90 @@ func fileExtension(filename string) string {
 
 func isDuplicate(archivePath string) bool {
 	return strings.Contains(filepath.ToSlash(archivePath), "/_duplicates/")
+}
+
+// TrashFile moves a file's registry record into the "trashed" state.
+// trashPath is the new on-disk location (inside _trash/), and the original
+// archive_path is saved as restore_path so the file can be restored later.
+func TrashFile(database *sql.DB, id int64, trashPath string) error {
+	res, err := database.Exec(`
+		UPDATE file_registry
+		SET    trash_path   = ?,
+		       restore_path = archive_path,
+		       archive_path = ?,
+		       trashed_at   = CURRENT_TIMESTAMP
+		WHERE  id = ? AND trashed_at IS NULL`,
+		trashPath, trashPath, id,
+	)
+	if err != nil {
+		return fmt.Errorf("trash file: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("file id %d not found or already trashed", id)
+	}
+	return nil
+}
+
+// ListTrashedFiles returns all files currently in the trash, newest first.
+func ListTrashedFiles(database *sql.DB) ([]File, error) {
+	rows, err := database.Query(`
+		SELECT id, original_path, archive_path, file_name, size, checksum,
+		       mod_time, trashed_at, restore_path
+		FROM   file_registry
+		WHERE  trashed_at IS NOT NULL
+		ORDER  BY trashed_at DESC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list trashed files: %w", err)
+	}
+	defer rows.Close()
+
+	var files []File
+	for rows.Next() {
+		var f File
+		var modTimeStr, trashedAtStr string
+		var restorePath sql.NullString
+		if err := rows.Scan(
+			&f.ID, &f.OriginalPath, &f.ArchivePath, &f.FileName,
+			&f.Size, &f.Checksum, &modTimeStr, &trashedAtStr, &restorePath,
+		); err != nil {
+			return nil, fmt.Errorf("scan trashed row: %w", err)
+		}
+		f.ModTime = parseTime(modTimeStr)
+		t := parseTime(trashedAtStr)
+		f.TrashedAt = &t
+		f.RestorePath = restorePath.String
+		f.Extension = fileExtension(f.FileName)
+		files = append(files, f)
+	}
+	return files, rows.Err()
+}
+
+// RestoreFileRecord clears the trash fields on a file_registry row and returns
+// the restore_path so the caller can move the file back on disk.
+func RestoreFileRecord(database *sql.DB, id int64) (restorePath string, err error) {
+	if err = database.QueryRow(
+		`SELECT restore_path FROM file_registry WHERE id = ? AND trashed_at IS NOT NULL`, id,
+	).Scan(&restorePath); err != nil {
+		if err == sql.ErrNoRows {
+			return "", fmt.Errorf("file id %d not found in trash", id)
+		}
+		return "", fmt.Errorf("restore record lookup: %w", err)
+	}
+
+	_, err = database.Exec(`
+		UPDATE file_registry
+		SET    archive_path = restore_path,
+		       trash_path   = NULL,
+		       restore_path = NULL,
+		       trashed_at   = NULL
+		WHERE  id = ?`, id,
+	)
+	if err != nil {
+		return "", fmt.Errorf("restore file record: %w", err)
+	}
+	return restorePath, nil
 }
 
 // parseTime handles the varying datetime formats SQLite may return.

--- a/internal/db/history.go
+++ b/internal/db/history.go
@@ -3,16 +3,19 @@ package db
 import (
 	"database/sql"
 	"fmt"
+	"sort"
 	"time"
 )
 
-// HistoryEntry is a row from the history table.
+// HistoryEntry is a row from the history table (or a synthesised entry from
+// file_actions). The Source field distinguishes the two origins.
 type HistoryEntry struct {
 	ID        int64     `json:"id"`
 	Timestamp time.Time `json:"timestamp"`
 	JobName   string    `json:"job_name"`
 	Status    string    `json:"status"`
 	Message   string    `json:"message"`
+	Source    string    `json:"source,omitempty"` // "archive" | "web_ui"
 }
 
 // HistoryListParams holds filter/pagination options for ListHistory.
@@ -131,10 +134,11 @@ func joinConditions(conds []string) string {
 	return result
 }
 
-// GetHistoryForFile returns the most recent history entries whose message
-// references the given archive path. This surfaces the audit trail for a
-// specific file in the viewer metadata sidebar.
-func GetHistoryForFile(database *sql.DB, archivePath string) ([]HistoryEntry, error) {
+// GetHistoryForFile returns a unified timeline of archive history entries and
+// web-UI file actions for the given file. CLI archive events are matched by
+// archive path; web-UI actions are looked up by file ID.
+func GetHistoryForFile(database *sql.DB, fileID int64, archivePath string) ([]HistoryEntry, error) {
+	// 1. CLI archive history — match by path substring in the message.
 	rows, err := database.Query(`
 		SELECT id, timestamp, job_name, status, message
 		FROM history
@@ -155,7 +159,56 @@ func GetHistoryForFile(database *sql.DB, archivePath string) ([]HistoryEntry, er
 			return nil, err
 		}
 		e.Timestamp = parseTime(tsStr)
+		e.Source = "archive"
 		entries = append(entries, e)
 	}
-	return entries, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// 2. Web-UI file actions — exact match on file_id.
+	if fileID > 0 {
+		arows, err := database.Query(`
+			SELECT id, performed_at, action, COALESCE(notes, '')
+			FROM   file_actions
+			WHERE  file_id = ?
+			ORDER  BY performed_at DESC
+			LIMIT  20
+		`, fileID)
+		if err != nil {
+			return nil, fmt.Errorf("file actions query: %w", err)
+		}
+		defer arows.Close()
+
+		for arows.Next() {
+			var a FileAction
+			var tsStr string
+			if err := arows.Scan(&a.ID, &tsStr, &a.Action, &a.Notes); err != nil {
+				return nil, err
+			}
+			a.PerformedAt = parseTime(tsStr)
+			entries = append(entries, HistoryEntry{
+				// Use a negative ID to avoid collisions with history table IDs.
+				ID:        -a.ID,
+				Timestamp: a.PerformedAt,
+				JobName:   "web-ui",
+				Status:    a.Action,
+				Message:   a.Notes,
+				Source:    "web_ui",
+			})
+		}
+		if err := arows.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	// Sort merged results newest first.
+	sortHistoryEntries(entries)
+	return entries, nil
+}
+
+func sortHistoryEntries(entries []HistoryEntry) {
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Timestamp.After(entries[j].Timestamp)
+	})
 }

--- a/internal/db/nav.go
+++ b/internal/db/nav.go
@@ -43,7 +43,7 @@ type NavTag struct {
 
 // GetNavTypes returns all extensions present in the archive, sorted by count desc.
 func GetNavTypes(database *sql.DB) ([]NavTypeEntry, error) {
-	rows, err := database.Query(`SELECT file_name, size FROM file_registry`)
+	rows, err := database.Query(`SELECT file_name, size FROM file_registry WHERE trashed_at IS NULL`)
 	if err != nil {
 		return nil, fmt.Errorf("nav types query: %w", err)
 	}
@@ -86,7 +86,7 @@ func GetNavDates(database *sql.DB) ([]NavYearEntry, error) {
 			SUBSTR(mod_time, 6, 2) AS mo,
 			COUNT(*)               AS cnt
 		FROM file_registry
-		WHERE mod_time IS NOT NULL AND mod_time != ''
+		WHERE mod_time IS NOT NULL AND mod_time != '' AND trashed_at IS NULL
 		GROUP BY yr, mo
 		ORDER BY yr DESC, mo ASC
 	`)

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -32,7 +32,7 @@ func GetStats(database *sql.DB) (*Stats, error) {
 	stats := &Stats{}
 
 	if err := database.QueryRow(
-		`SELECT COUNT(*), COALESCE(SUM(size), 0) FROM file_registry`,
+		`SELECT COUNT(*), COALESCE(SUM(size), 0) FROM file_registry WHERE trashed_at IS NULL`,
 	).Scan(&stats.TotalFiles, &stats.TotalSize); err != nil {
 		return nil, fmt.Errorf("stats query: %w", err)
 	}
@@ -44,7 +44,7 @@ func GetStats(database *sql.DB) (*Stats, error) {
 		return nil, fmt.Errorf("tagged files query: %w", err)
 	}
 
-	rows, err := database.Query(`SELECT file_name, size FROM file_registry`)
+	rows, err := database.Query(`SELECT file_name, size FROM file_registry WHERE trashed_at IS NULL`)
 	if err != nil {
 		return nil, fmt.Errorf("extension query: %w", err)
 	}

--- a/internal/db/trash.go
+++ b/internal/db/trash.go
@@ -1,0 +1,168 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// FileAction is a row from the file_actions audit table.
+type FileAction struct {
+	ID          int64      `json:"id"`
+	FileID      *int64     `json:"file_id"`
+	FileName    string     `json:"file_name"`
+	ArchivePath string     `json:"archive_path"`
+	Action      string     `json:"action"` // "trashed" | "restored" | "permanently_deleted"
+	PerformedAt time.Time  `json:"performed_at"`
+	Notes       string     `json:"notes,omitempty"`
+}
+
+// FileActionListParams holds filter/pagination options for ListAllFileActions.
+type FileActionListParams struct {
+	Action  string // filter by action value; empty = all
+	Search  string // LIKE search on file_name or archive_path
+	From    string // ISO date "YYYY-MM-DD"
+	To      string
+	Page    int
+	PerPage int
+}
+
+// FileActionListResult is the paginated response for ListAllFileActions.
+type FileActionListResult struct {
+	Actions    []FileAction `json:"actions"`
+	Total      int64        `json:"total"`
+	Page       int          `json:"page"`
+	PerPage    int          `json:"per_page"`
+	TotalPages int          `json:"total_pages"`
+}
+
+// LogFileAction inserts a row into the file_actions audit table.
+// fileID may be nil when the registry record no longer exists.
+func LogFileAction(database *sql.DB, fileID *int64, fileName, archivePath, action, notes string) error {
+	_, err := database.Exec(`
+		INSERT INTO file_actions (file_id, file_name, archive_path, action, notes)
+		VALUES (?, ?, ?, ?, ?)`,
+		fileID, fileName, archivePath, action, notes,
+	)
+	if err != nil {
+		return fmt.Errorf("log file action: %w", err)
+	}
+	return nil
+}
+
+// ListFileActions returns all audit actions for a specific file, newest first.
+// It matches by file_id when the record still exists, and also by archive_path
+// so that pre-trash CLI history and the post-trash path both surface entries.
+func ListFileActions(database *sql.DB, fileID int64) ([]FileAction, error) {
+	rows, err := database.Query(`
+		SELECT id, file_id, file_name, archive_path, action, performed_at,
+		       COALESCE(notes, '')
+		FROM   file_actions
+		WHERE  file_id = ?
+		ORDER  BY performed_at DESC`,
+		fileID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list file actions: %w", err)
+	}
+	defer rows.Close()
+	return scanFileActions(rows)
+}
+
+// ListAllFileActions returns a paginated, optionally filtered list of all audit actions.
+func ListAllFileActions(database *sql.DB, p FileActionListParams) (*FileActionListResult, error) {
+	if p.Page < 1 {
+		p.Page = 1
+	}
+	if p.PerPage < 1 || p.PerPage > 200 {
+		p.PerPage = 50
+	}
+
+	var conditions []string
+	var args []interface{}
+
+	if p.Action != "" {
+		conditions = append(conditions, `action = ?`)
+		args = append(args, p.Action)
+	}
+	if p.Search != "" {
+		conditions = append(conditions, `(file_name LIKE ? OR archive_path LIKE ?)`)
+		like := "%" + p.Search + "%"
+		args = append(args, like, like)
+	}
+	if p.From != "" {
+		conditions = append(conditions, `performed_at >= ?`)
+		args = append(args, p.From)
+	}
+	if p.To != "" {
+		conditions = append(conditions, `performed_at <= ?`)
+		args = append(args, p.To+" 23:59:59")
+	}
+
+	where := ""
+	if len(conditions) > 0 {
+		where = "WHERE " + strings.Join(conditions, " AND ")
+	}
+
+	var total int64
+	if err := database.QueryRow(
+		"SELECT COUNT(*) FROM file_actions "+where, args...,
+	).Scan(&total); err != nil {
+		return nil, fmt.Errorf("file actions count: %w", err)
+	}
+
+	offset := (p.Page - 1) * p.PerPage
+	queryArgs := append(args, p.PerPage, offset)
+	rows, err := database.Query(
+		`SELECT id, file_id, file_name, archive_path, action, performed_at,
+		        COALESCE(notes, '')
+		 FROM   file_actions `+where+`
+		 ORDER  BY performed_at DESC
+		 LIMIT  ? OFFSET ?`,
+		queryArgs...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("file actions query: %w", err)
+	}
+	defer rows.Close()
+
+	actions, err := scanFileActions(rows)
+	if err != nil {
+		return nil, err
+	}
+
+	totalPages := int((total + int64(p.PerPage) - 1) / int64(p.PerPage))
+	if totalPages < 1 {
+		totalPages = 1
+	}
+	return &FileActionListResult{
+		Actions:    actions,
+		Total:      total,
+		Page:       p.Page,
+		PerPage:    p.PerPage,
+		TotalPages: totalPages,
+	}, nil
+}
+
+func scanFileActions(rows *sql.Rows) ([]FileAction, error) {
+	var actions []FileAction
+	for rows.Next() {
+		var a FileAction
+		var fileID sql.NullInt64
+		var tsStr string
+		if err := rows.Scan(
+			&a.ID, &fileID, &a.FileName, &a.ArchivePath,
+			&a.Action, &tsStr, &a.Notes,
+		); err != nil {
+			return nil, fmt.Errorf("scan file action: %w", err)
+		}
+		if fileID.Valid {
+			v := fileID.Int64
+			a.FileID = &v
+		}
+		a.PerformedAt = parseTime(tsStr)
+		actions = append(actions, a)
+	}
+	return actions, rows.Err()
+}

--- a/internal/webui/web/index.html
+++ b/internal/webui/web/index.html
@@ -32,7 +32,7 @@
       <span class="text-lg font-semibold tracking-tight">filearchiver</span>
     </div>
     <nav class="flex gap-1">
-      <template x-for="[id, label] in [['dashboard','Dashboard'],['files','Files'],['search','Search'],['duplicates','Duplicates'],['tags','Tags'],['history','History'],['settings','Settings']]" :key="id">
+      <template x-for="[id, label] in [['dashboard','Dashboard'],['files','Files'],['search','Search'],['duplicates','Duplicates'],['tags','Tags'],['history','History'],['trash','Trash'],['settings','Settings']]" :key="id">
         <button @click="page = id"
           :class="page === id ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-100'"
           class="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
@@ -468,93 +468,180 @@
       <!-- ════════════════ HISTORY ════════════════ -->
       <div x-show="page === 'history'" class="p-6 max-w-6xl mx-auto">
         <div class="flex items-center justify-between mb-4">
-          <h1 class="text-2xl font-bold">Archive History</h1>
-          <!-- Status filter -->
-          <select x-model="historyStatusFilter"
-            class="border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500">
-            <option value="">All statuses</option>
-            <option value="SUCCESS">Success</option>
-            <option value="FAILED">Failed</option>
-            <option value="SKIPPED">Skipped</option>
-          </select>
-        </div>
-
-        <!-- Additional filters row -->
-        <div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
-          <input type="text" x-model.debounce.400ms="historyJobFilter"
-            placeholder="Job name…"
-            class="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
-          <input type="text" x-model.debounce.400ms="historyMessageFilter"
-            placeholder="Message contains…"
-            class="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
-          <input type="date" x-model="historyFromDate" title="From date"
-            class="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
-          <input type="date" x-model="historyToDate" title="To date"
-            class="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
-        </div>
-
-        <!-- Summary bar -->
-        <div x-show="historyResult" class="grid grid-cols-3 gap-4 mb-6">
-          <div class="bg-white rounded-xl border border-gray-200 p-4 shadow-sm text-center">
-            <p class="text-2xl font-bold text-gray-800" x-text="historyResult?.total?.toLocaleString() ?? 0"></p>
-            <p class="text-xs text-gray-500 mt-0.5">Total entries</p>
-          </div>
-          <div class="bg-green-50 rounded-xl border border-green-100 p-4 shadow-sm text-center">
-            <p class="text-2xl font-bold text-green-700" x-text="history.filter(h=>h.status==='SUCCESS').length"></p>
-            <p class="text-xs text-green-600 mt-0.5">Success (this page)</p>
-          </div>
-          <div class="bg-red-50 rounded-xl border border-red-100 p-4 shadow-sm text-center">
-            <p class="text-2xl font-bold text-red-700" x-text="history.filter(h=>h.status==='FAILED').length"></p>
-            <p class="text-xs text-red-600 mt-0.5">Failed (this page)</p>
+          <h1 class="text-2xl font-bold">History</h1>
+          <!-- Sub-tab toggle -->
+          <div class="flex border border-gray-300 rounded-lg overflow-hidden">
+            <button @click="historySubTab = 'archive'"
+              :class="historySubTab === 'archive' ? 'bg-blue-50 text-blue-700' : 'bg-white text-gray-600 hover:bg-gray-50'"
+              class="px-4 py-2 text-sm font-medium transition-colors">Archive Log</button>
+            <button @click="historySubTab = 'actions'; loadFileActions()"
+              :class="historySubTab === 'actions' ? 'bg-blue-50 text-blue-700' : 'bg-white text-gray-600 hover:bg-gray-50'"
+              class="px-4 py-2 text-sm font-medium border-l border-gray-300 transition-colors">File Actions</button>
           </div>
         </div>
 
-        <div class="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
-          <table class="w-full text-sm">
-            <thead class="bg-gray-50 border-b border-gray-200">
-              <tr>
-                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Timestamp</th>
-                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Job</th>
-                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Status</th>
-                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Message</th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-gray-100">
-              <template x-for="h in history" :key="h.id">
-                <tr class="hover:bg-gray-50 transition-colors">
-                  <td class="px-4 py-3 text-gray-500 whitespace-nowrap text-xs"
-                    x-text="formatDateTime(h.timestamp)"></td>
-                  <td class="px-4 py-3 font-mono text-xs text-gray-600" x-text="h.job_name"></td>
-                  <td class="px-4 py-3">
-                    <span class="px-2 py-0.5 rounded-full text-xs font-medium"
-                      :class="{
-                        'bg-green-100 text-green-700': h.status === 'SUCCESS',
-                        'bg-red-100   text-red-700':   h.status === 'FAILED',
-                        'bg-gray-100  text-gray-600':  h.status === 'SKIPPED'
-                      }" x-text="h.status"></span>
-                  </td>
-                  <td class="px-4 py-3 text-gray-500 text-xs font-mono truncate max-w-sm"
-                    x-text="h.message"></td>
-                </tr>
-              </template>
-              <tr x-show="history.length === 0 && !historyLoading">
-                <td colspan="4" class="px-4 py-12 text-center text-gray-400">No history entries</td>
-              </tr>
-            </tbody>
-          </table>
+        <!-- ── Archive Log sub-tab ── -->
+        <div x-show="historySubTab === 'archive'">
+          <!-- Filters row -->
+          <div class="flex flex-wrap items-center gap-3 mb-6">
+            <select x-model="historyStatusFilter"
+              class="border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+              <option value="">All statuses</option>
+              <option value="SUCCESS">Success</option>
+              <option value="FAILED">Failed</option>
+              <option value="SKIPPED">Skipped</option>
+            </select>
+            <input type="text" x-model.debounce.400ms="historyJobFilter"
+              placeholder="Job name…"
+              class="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            <input type="text" x-model.debounce.400ms="historyMessageFilter"
+              placeholder="Message contains…"
+              class="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            <input type="date" x-model="historyFromDate" title="From date"
+              class="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            <input type="date" x-model="historyToDate" title="To date"
+              class="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          </div>
 
-          <div x-show="historyResult && historyResult.total > historyResult.per_page"
-            class="flex items-center justify-between px-4 py-3 border-t border-gray-200 bg-gray-50 text-sm text-gray-600">
-            <span x-text="'Total: ' + historyResult?.total?.toLocaleString() + ' entries'"></span>
-            <div class="flex gap-2">
-              <button @click="historyPage--" :disabled="historyPage <= 1"
-                class="px-3 py-1.5 rounded-lg border border-gray-300 disabled:opacity-40 hover:bg-gray-100">← Previous</button>
-              <button @click="historyPage++" :disabled="historyPage >= historyResult?.total_pages"
-                class="px-3 py-1.5 rounded-lg border border-gray-300 disabled:opacity-40 hover:bg-gray-100">Next →</button>
+          <!-- Summary bar -->
+          <div x-show="historyResult" class="grid grid-cols-3 gap-4 mb-6">
+            <div class="bg-white rounded-xl border border-gray-200 p-4 shadow-sm text-center">
+              <p class="text-2xl font-bold text-gray-800" x-text="historyResult?.total?.toLocaleString() ?? 0"></p>
+              <p class="text-xs text-gray-500 mt-0.5">Total entries</p>
+            </div>
+            <div class="bg-green-50 rounded-xl border border-green-100 p-4 shadow-sm text-center">
+              <p class="text-2xl font-bold text-green-700" x-text="history.filter(h=>h.status==='SUCCESS').length"></p>
+              <p class="text-xs text-green-600 mt-0.5">Success (this page)</p>
+            </div>
+            <div class="bg-red-50 rounded-xl border border-red-100 p-4 shadow-sm text-center">
+              <p class="text-2xl font-bold text-red-700" x-text="history.filter(h=>h.status==='FAILED').length"></p>
+              <p class="text-xs text-red-600 mt-0.5">Failed (this page)</p>
             </div>
           </div>
-        </div>
-      </div>
+
+          <div class="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+            <table class="w-full text-sm">
+              <thead class="bg-gray-50 border-b border-gray-200">
+                <tr>
+                  <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Timestamp</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Job</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Status</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Message</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-100">
+                <template x-for="h in history" :key="h.id">
+                  <tr class="hover:bg-gray-50 transition-colors">
+                    <td class="px-4 py-3 text-gray-500 whitespace-nowrap text-xs"
+                      x-text="formatDateTime(h.timestamp)"></td>
+                    <td class="px-4 py-3 font-mono text-xs text-gray-600" x-text="h.job_name"></td>
+                    <td class="px-4 py-3">
+                      <span class="px-2 py-0.5 rounded-full text-xs font-medium"
+                        :class="{
+                          'bg-green-100 text-green-700': h.status === 'SUCCESS',
+                          'bg-red-100   text-red-700':   h.status === 'FAILED',
+                          'bg-gray-100  text-gray-600':  h.status === 'SKIPPED'
+                        }" x-text="h.status"></span>
+                    </td>
+                    <td class="px-4 py-3 text-gray-500 text-xs font-mono truncate max-w-sm"
+                      x-text="h.message"></td>
+                  </tr>
+                </template>
+                <tr x-show="history.length === 0 && !historyLoading">
+                  <td colspan="4" class="px-4 py-12 text-center text-gray-400">No history entries</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <div x-show="historyResult && historyResult.total > historyResult.per_page"
+              class="flex items-center justify-between px-4 py-3 border-t border-gray-200 bg-gray-50 text-sm text-gray-600">
+              <span x-text="'Total: ' + historyResult?.total?.toLocaleString() + ' entries'"></span>
+              <div class="flex gap-2">
+                <button @click="historyPage--" :disabled="historyPage <= 1"
+                  class="px-3 py-1.5 rounded-lg border border-gray-300 disabled:opacity-40 hover:bg-gray-100">← Previous</button>
+                <button @click="historyPage++" :disabled="historyPage >= historyResult?.total_pages"
+                  class="px-3 py-1.5 rounded-lg border border-gray-300 disabled:opacity-40 hover:bg-gray-100">Next →</button>
+              </div>
+            </div>
+          </div>
+        </div><!-- end archive log sub-tab -->
+
+        <!-- ── File Actions sub-tab ── -->
+        <div x-show="historySubTab === 'actions'">
+          <!-- Filters -->
+          <div class="flex flex-wrap items-center gap-3 mb-6">
+            <select x-model="fileActionsFilter"
+              class="border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+              <option value="">All actions</option>
+              <option value="trashed">Trashed</option>
+              <option value="restored">Restored</option>
+              <option value="permanently_deleted">Permanently Deleted</option>
+            </select>
+            <input type="text" x-model.debounce.400ms="fileActionsSearch"
+              placeholder="Search filename or path…"
+              class="flex-1 min-w-48 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          </div>
+
+          <!-- Loading -->
+          <div x-show="fileActionsLoading" class="text-center text-gray-400 py-12">
+            <svg class="animate-spin w-5 h-5 mx-auto mb-2" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/>
+            </svg>
+            Loading…
+          </div>
+
+          <div x-show="!fileActionsLoading" class="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+            <table class="w-full text-sm">
+              <thead class="bg-gray-50 border-b border-gray-200">
+                <tr>
+                  <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Timestamp</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">File</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Action</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide hidden md:table-cell">Path at time of action</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide hidden lg:table-cell">Notes</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-100">
+                <template x-for="a in fileActions" :key="a.id">
+                  <tr class="hover:bg-gray-50 transition-colors">
+                    <td class="px-4 py-3 text-gray-500 whitespace-nowrap text-xs"
+                      x-text="formatDateTime(a.performed_at)"></td>
+                    <td class="px-4 py-3 font-medium truncate max-w-xs" x-text="a.file_name"></td>
+                    <td class="px-4 py-3">
+                      <span class="px-2 py-0.5 rounded-full text-xs font-medium"
+                        :class="{
+                          'bg-red-100    text-red-700':    a.action === 'trashed',
+                          'bg-green-100  text-green-700':  a.action === 'restored',
+                          'bg-gray-900   text-gray-100':   a.action === 'permanently_deleted'
+                        }" x-text="a.action.replace(/_/g,' ')"></span>
+                    </td>
+                    <td class="px-4 py-3 text-gray-400 text-xs font-mono truncate max-w-xs hidden md:table-cell"
+                      x-text="a.archive_path"></td>
+                    <td class="px-4 py-3 text-gray-400 text-xs hidden lg:table-cell"
+                      x-text="a.notes"></td>
+                  </tr>
+                </template>
+                <tr x-show="fileActions.length === 0 && !fileActionsLoading">
+                  <td colspan="5" class="px-4 py-12 text-center text-gray-400">No file actions recorded yet</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <div x-show="fileActionsResult && fileActionsResult.total > fileActionsResult.per_page"
+              class="flex items-center justify-between px-4 py-3 border-t border-gray-200 bg-gray-50 text-sm text-gray-600">
+              <span x-text="'Total: ' + fileActionsResult?.total?.toLocaleString() + ' entries'"></span>
+              <div class="flex gap-2">
+                <button @click="fileActionsPage--" :disabled="fileActionsPage <= 1"
+                  class="px-3 py-1.5 rounded-lg border border-gray-300 disabled:opacity-40 hover:bg-gray-100">← Previous</button>
+                <button @click="fileActionsPage++" :disabled="fileActionsPage >= fileActionsResult?.total_pages"
+                  class="px-3 py-1.5 rounded-lg border border-gray-300 disabled:opacity-40 hover:bg-gray-100">Next →</button>
+              </div>
+            </div>
+          </div>
+        </div><!-- end file actions sub-tab -->
+
+      </div><!-- end history page -->
 
       <!-- ══════════════════════════════════════════════════════════════
            TAGS PAGE
@@ -1103,6 +1190,103 @@
         </section>
       </div><!-- end settings page -->
 
+      <!-- ════════════════ TRASH ════════════════ -->
+      <div x-show="page === 'trash'" class="p-6 max-w-6xl mx-auto">
+        <div class="flex items-center justify-between mb-6">
+          <div>
+            <h1 class="text-xl font-semibold text-gray-800">Trash</h1>
+            <p class="text-sm text-gray-500 mt-0.5"
+               x-text="trashFiles.length + ' file' + (trashFiles.length === 1 ? '' : 's') + ' in trash'"></p>
+          </div>
+          <button @click="emptyTrash()"
+                  :disabled="trashFiles.length === 0 || (serverSettings && serverSettings.readonly)"
+                  class="flex items-center gap-1.5 px-3 py-2 rounded-lg bg-red-600 hover:bg-red-500 text-white text-sm font-medium disabled:opacity-40 transition-colors">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+            </svg>
+            Empty Trash
+          </button>
+        </div>
+
+        <!-- Info banner -->
+        <div class="flex items-start gap-2 mb-6 px-4 py-3 bg-amber-50 border border-amber-200 rounded-xl text-amber-800 text-sm">
+          <svg class="w-4 h-4 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+          </svg>
+          Files in Trash are hidden from the archive but still on disk. Restore them to bring them back, or delete permanently to free disk space.
+        </div>
+
+        <!-- Loading -->
+        <div x-show="trashLoading" class="text-center text-gray-400 py-16">
+          <svg class="animate-spin w-6 h-6 mx-auto mb-3" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/>
+          </svg>
+          Loading…
+        </div>
+
+        <!-- Empty state -->
+        <div x-show="!trashLoading && trashFiles.length === 0"
+          class="bg-white rounded-xl border border-gray-200 p-16 text-center shadow-sm">
+          <svg class="w-12 h-12 mx-auto mb-3 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+              d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+          </svg>
+          <p class="text-gray-500 font-medium">Trash is empty</p>
+        </div>
+
+        <!-- Trash file list -->
+        <div x-show="!trashLoading && trashFiles.length > 0"
+          class="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+          <table class="w-full text-sm">
+            <thead class="bg-gray-50 border-b border-gray-200">
+              <tr>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Name</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Type</th>
+                <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wide">Size</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Trashed</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide hidden lg:table-cell">Restore path</th>
+                <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wide">Actions</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+              <template x-for="f in trashFiles" :key="f.id">
+                <tr class="hover:bg-gray-50 transition-colors">
+                  <td class="px-4 py-3 font-medium truncate max-w-xs" x-text="f.file_name"></td>
+                  <td class="px-4 py-3">
+                    <span class="inline-flex items-center gap-1">
+                      <span class="w-2 h-2 rounded-sm inline-block"
+                        :style="'background:' + extColor(f.extension)"></span>
+                      <span class="font-mono text-xs text-gray-600" x-text="f.extension || 'none'"></span>
+                    </span>
+                  </td>
+                  <td class="px-4 py-3 text-right text-gray-500 tabular-nums" x-text="formatBytes(f.size)"></td>
+                  <td class="px-4 py-3 text-gray-500 whitespace-nowrap text-xs" x-text="formatDateTime(f.trashed_at)"></td>
+                  <td class="px-4 py-3 text-gray-400 text-xs font-mono truncate max-w-xs hidden lg:table-cell"
+                    x-text="f.restore_path"></td>
+                  <td class="px-4 py-3">
+                    <div class="flex items-center justify-end gap-2">
+                      <button @click="restoreTrashFile(f)"
+                              :disabled="serverSettings && serverSettings.readonly"
+                              class="px-2.5 py-1 rounded-lg bg-blue-50 hover:bg-blue-100 text-blue-700 text-xs font-medium disabled:opacity-40 transition-colors">
+                        ↩ Restore
+                      </button>
+                      <button @click="permanentlyDeleteTrashFile(f)"
+                              :disabled="serverSettings && serverSettings.readonly"
+                              class="px-2.5 py-1 rounded-lg bg-red-50 hover:bg-red-100 text-red-700 text-xs font-medium disabled:opacity-40 transition-colors">
+                        Delete permanently
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              </template>
+            </tbody>
+          </table>
+        </div>
+      </div><!-- end trash page -->
+
     </main>
   </div><!-- end body flex -->
 
@@ -1393,6 +1577,9 @@
           <button @click="loadViewerHistory()"
                   :class="viewerTab === 'history' ? 'border-b-2 border-blue-400 text-white' : 'text-white/50 hover:text-white/80'"
                   class="flex-1 py-2.5 text-xs font-medium transition-colors">History</button>
+          <button @click="viewerTab = 'manage'"
+                  :class="viewerTab === 'manage' ? 'border-b-2 border-red-400 text-white' : 'text-white/50 hover:text-white/80'"
+                  class="flex-1 py-2.5 text-xs font-medium transition-colors">Manage</button>
         </div>
 
         <!-- Info tab -->
@@ -1509,6 +1696,38 @@
               </div>
             </template>
           </div>
+        </div>
+
+        <!-- Manage tab -->
+        <div x-show="viewerTab === 'manage'" class="flex-1 overflow-y-auto p-4 space-y-4">
+          <template x-if="viewerFile">
+            <div class="space-y-4">
+              <div class="bg-white/5 border border-white/10 rounded-lg p-3">
+                <p class="text-white/70 text-xs leading-relaxed">
+                  Moving a file to Trash removes it from the archive view.
+                  You can restore it or permanently delete it from the
+                  <button @click="closeViewer(); page='trash'" class="underline hover:text-white">Trash</button> page.
+                </p>
+              </div>
+              <template x-if="viewerFile && viewerFile.is_duplicate">
+                <div class="bg-yellow-500/20 border border-yellow-500/30 rounded-lg px-3 py-2">
+                  <p class="text-yellow-300 text-xs font-medium">⚠ This is a duplicate file</p>
+                </div>
+              </template>
+              <button @click="trashViewerFile()"
+                      :disabled="serverSettings && serverSettings.readonly"
+                      class="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-red-600 hover:bg-red-500 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-medium transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+                </svg>
+                Move to Trash
+              </button>
+              <template x-if="serverSettings && serverSettings.readonly">
+                <p class="text-white/30 text-xs text-center">Server is in read-only mode</p>
+              </template>
+            </div>
+          </template>
         </div>
 
       </div><!-- end sidebar -->

--- a/internal/webui/web/static/app.js
+++ b/internal/webui/web/static/app.js
@@ -109,6 +109,21 @@ document.addEventListener('alpine:init', () => {
     dupConfirmDanger:   true,
     _dupConfirmFn:      null,
 
+    // ── Trash page ────────────────────────────────────────────────────────────
+    trashFiles:   [],
+    trashLoading: false,
+
+    // ── File Actions audit log ────────────────────────────────────────────────
+    fileActions:        [],
+    fileActionsResult:  null,
+    fileActionsLoading: false,
+    fileActionsPage:    1,
+    fileActionsFilter:  '',
+    fileActionsSearch:  '',
+
+    // ── History sub-tab ('archive' | 'actions') ───────────────────────────────
+    historySubTab: 'archive',
+
     // ── Toast notification ────────────────────────────────────────────────────
     toastMsg:     '',
     toastVisible: false,
@@ -154,12 +169,14 @@ document.addEventListener('alpine:init', () => {
 
       this.$watch('page', p => {
         this.updateHash();
-        if (p === 'files')      this.loadFiles();
-        if (p === 'history')    this.loadHistory();
-        if (p === 'tags')       this.loadTagsPage();
-        if (p === 'duplicates') this.loadDuplicates();
-        if (p === 'search')     this.runSearch();
-        if (p === 'settings')   this.loadSettings();
+        if (p === 'files')        this.loadFiles();
+        if (p === 'history')      this.loadHistory();
+        if (p === 'tags')         this.loadTagsPage();
+        if (p === 'duplicates')   this.loadDuplicates();
+        if (p === 'search')       this.runSearch();
+        if (p === 'settings')     this.loadSettings();
+        if (p === 'trash')        this.loadTrash();
+        if (p === 'file-actions') this.loadFileActions();
       });
 
       this.$watch('filesPage',  () => this.loadFiles());
@@ -173,6 +190,10 @@ document.addEventListener('alpine:init', () => {
       this.$watch('historyMessageFilter', () => { this.historyPage = 1; this.loadHistory(); });
       this.$watch('historyFromDate',      () => { this.historyPage = 1; this.loadHistory(); });
       this.$watch('historyToDate',        () => { this.historyPage = 1; this.loadHistory(); });
+
+      this.$watch('fileActionsPage',   () => this.loadFileActions());
+      this.$watch('fileActionsFilter', () => { this.fileActionsPage = 1; this.loadFileActions(); });
+      this.$watch('fileActionsSearch', () => { this.fileActionsPage = 1; this.loadFileActions(); });
 
       this.$watch('searchQuery',        () => { this.searchPage = 1; this.runSearch(); this.updateHash(); });
       this.$watch('searchExt',          () => { this.searchPage = 1; this.runSearch(); });
@@ -593,7 +614,7 @@ document.addEventListener('alpine:init', () => {
 
     // ── URL hash state ────────────────────────────────────────────────────────
     updateHash() {
-      const pages = ['dashboard','files','search','history','tags','duplicates','settings'];
+      const pages = ['dashboard','files','search','history','tags','duplicates','settings','trash'];
       if (!pages.includes(this.page)) return;
       let hash = this.page;
       if (this.page === 'search' && this.searchQuery) {
@@ -611,7 +632,7 @@ document.addEventListener('alpine:init', () => {
       const raw = window.location.hash.slice(1);
       if (!raw) return;
       const [path, qs] = raw.split('?');
-      const valid = ['dashboard','files','search','history','tags','duplicates','settings'];
+      const valid = ['dashboard','files','search','history','tags','duplicates','settings','trash'];
       if (valid.includes(path)) this.page = path;
       if (path === 'search' && qs) {
         const sp = new URLSearchParams(qs);
@@ -781,7 +802,7 @@ document.addEventListener('alpine:init', () => {
         this.showToast('Error: ' + (j.error || res.status));
         return false;
       }
-      this.showToast('Duplicate deleted');
+      this.showToast('Moved to Trash');
       this.loadStats();
       return true;
     },
@@ -808,6 +829,90 @@ document.addEventListener('alpine:init', () => {
       if (group.duplicates.length === 0) {
         const idx = this.dupGroups.indexOf(group);
         if (idx >= 0) this.dupGroups.splice(idx, 1);
+      }
+    },
+
+    // ── Trash page ────────────────────────────────────────────────────────────
+    async loadTrash() {
+      this.trashLoading = true;
+      try {
+        const res = await fetch('/api/trash');
+        this.trashFiles = await res.json() ?? [];
+      } catch(e) {
+        console.error('trash', e);
+        this.trashFiles = [];
+      } finally {
+        this.trashLoading = false;
+      }
+    },
+
+    async trashViewerFile() {
+      if (!this.viewerFile) return;
+      const id = this.viewerFile.id;
+      const res = await fetch(`/api/files/${id}?confirm=true`, { method: 'DELETE' });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        this.showToast('Error: ' + (j.error || res.status));
+        return;
+      }
+      this.showToast('Moved to Trash');
+      this.files = this.files.filter(f => f.id !== id);
+      this.closeViewer();
+      this.loadStats();
+      this.loadNavData();
+    },
+
+    async restoreTrashFile(file) {
+      const res = await fetch(`/api/trash/${file.id}/restore`, { method: 'POST' });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        this.showToast('Error: ' + (j.error || res.status));
+        return;
+      }
+      this.showToast('File restored');
+      await this.loadTrash();
+      this.loadStats();
+      this.loadNavData();
+    },
+
+    async permanentlyDeleteTrashFile(file) {
+      const res = await fetch(`/api/trash/${file.id}?confirm=true`, { method: 'DELETE' });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        this.showToast('Error: ' + (j.error || res.status));
+        return;
+      }
+      this.showToast('Permanently deleted');
+      this.trashFiles = this.trashFiles.filter(f => f.id !== file.id);
+    },
+
+    async emptyTrash() {
+      const res = await fetch('/api/trash?confirm=true', { method: 'DELETE' });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        this.showToast('Error: ' + (j.error || res.status));
+        return;
+      }
+      const j = await res.json();
+      this.showToast(`Permanently deleted ${j.deleted ?? 0} file(s)`);
+      this.trashFiles = [];
+      this.loadStats();
+    },
+
+    // ── File Actions audit log ────────────────────────────────────────────────
+    async loadFileActions() {
+      this.fileActionsLoading = true;
+      try {
+        const p = new URLSearchParams({ page: this.fileActionsPage, per_page: 50 });
+        if (this.fileActionsFilter) p.set('action', this.fileActionsFilter);
+        if (this.fileActionsSearch) p.set('q', this.fileActionsSearch);
+        const res = await fetch('/api/file-actions?' + p);
+        this.fileActionsResult = await res.json();
+        this.fileActions = this.fileActionsResult.actions ?? [];
+      } catch(e) {
+        console.error('file actions', e);
+      } finally {
+        this.fileActionsLoading = false;
       }
     },
 


### PR DESCRIPTION
- Soft-delete: files moved to _trash/ instead of permanent delete
- New Trash page: list, restore, and permanently delete trashed files
- Empty Trash button to permanently delete all trashed files
- Manage tab in media viewer with Move to Trash button
- file_actions audit table records trashed/restored/permanently_deleted events
- File Actions sub-tab in History page shows full audit log with filters
- Viewer History tab merges CLI archive history with web-UI file actions
- All queries (stats, nav, files, duplicates) exclude trashed files
- DB migration adds trashed_at, trash_path, restore_path to file_registry
- Duplicate delete (Duplicates page) now also soft-deletes to trash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Trash page for reviewing, restoring, permanently deleting, or emptying trashed files.
  * Files moved to Trash are hidden from archive listings, searches, statistics, and duplicate views.
  * Added a File Actions audit log with filtering, searching, and pagination.
  * Added file management controls in the media viewer.
  * File history now combines archive events with web-based actions.

* **Bug Fixes**
  * Improved handling of duplicate filenames in Trash.
  * Added safer confirmation checks for permanent deletions and emptying Trash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->