### PR TITLE
Add bulk move to trash on Files tab

### DIFF
--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -2,7 +2,10 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 
 	"filearchiver/internal/db"
@@ -59,6 +62,85 @@ func handleGetFile(cfg Config) http.HandlerFunc {
 		}
 
 		writeJSON(w, http.StatusOK, file)
+	}
+}
+
+// handleBulkTrashFiles moves multiple files to trash in one request.
+// Body: {"ids": [1, 2, 3], "confirm": true}
+func handleBulkTrashFiles(cfg Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			IDs     []int64 `json:"ids"`
+			Confirm bool    `json:"confirm"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+		if !body.Confirm {
+			writeError(w, http.StatusBadRequest, "confirm must be true")
+			return
+		}
+		if len(body.IDs) == 0 {
+			writeError(w, http.StatusBadRequest, "no file ids provided")
+			return
+		}
+		if len(body.IDs) > 500 {
+			writeError(w, http.StatusBadRequest, "too many ids (max 500)")
+			return
+		}
+
+		absRoot, _ := filepath.Abs(cfg.ArchiveRoot)
+		trashDir := filepath.Join(absRoot, "_trash")
+		if err := os.MkdirAll(trashDir, 0755); err != nil {
+			writeError(w, http.StatusInternalServerError, "cannot create trash directory: "+err.Error())
+			return
+		}
+
+		trashed := 0
+		var errs []string
+
+		for _, id := range body.IDs {
+			file, err := db.GetFile(cfg.DB, id)
+			if err != nil || file == nil {
+				errs = append(errs, fmt.Sprintf("id %d: not found", id))
+				continue
+			}
+
+			absPath, _ := filepath.Abs(file.ArchivePath)
+			if !isUnderRoot(absPath, absRoot) {
+				errs = append(errs, fmt.Sprintf("%s: path outside archive root", file.FileName))
+				continue
+			}
+
+			trashPath, err := resolveTrashPath(trashDir, file.FileName)
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("%s: %s", file.FileName, err.Error()))
+				continue
+			}
+
+			if err := os.Rename(absPath, trashPath); err != nil && !os.IsNotExist(err) {
+				errs = append(errs, fmt.Sprintf("%s: %s", file.FileName, err.Error()))
+				continue
+			}
+
+			if err := db.TrashFile(cfg.DB, id, trashPath); err != nil {
+				errs = append(errs, fmt.Sprintf("%s: %s", file.FileName, err.Error()))
+				continue
+			}
+
+			fID := id
+			_ = db.LogFileAction(cfg.DB, &fID, file.FileName, file.ArchivePath,
+				"trashed", "bulk move to trash via web UI")
+
+			trashed++
+		}
+
+		resp := map[string]any{"trashed": trashed}
+		if len(errs) > 0 {
+			resp["errors"] = errs
+		}
+		writeJSON(w, http.StatusOK, resp)
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -41,6 +41,7 @@ func NewRouter(cfg Config) http.Handler {
 
 		r.Route("/files", func(r chi.Router) {
 			r.Get("/", handleListFiles(cfg))
+			r.Post("/bulk-trash", readonlyGuard(cfg, handleBulkTrashFiles(cfg)))
 			r.Get("/{id}", handleGetFile(cfg))
 			r.Delete("/{id}", readonlyGuard(cfg, handleDeleteFile(cfg)))
 			r.Get("/{id}/history", handleGetFileHistory(cfg))

--- a/internal/webui/web/index.html
+++ b/internal/webui/web/index.html
@@ -299,6 +299,34 @@
               </svg>
             </button>
           </div>
+
+          <!-- Select mode toggle -->
+          <button @click="toggleSelectMode()"
+            :class="filesSelecting ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'"
+            class="flex items-center gap-1.5 px-3 py-2 rounded-lg border text-sm font-medium transition-colors"
+            :disabled="serverSettings && serverSettings.readonly">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+            </svg>
+            <span x-text="filesSelecting ? 'Cancel' : 'Select'"></span>
+          </button>
+        </div>
+
+        <!-- Bulk action bar -->
+        <div x-show="filesSelecting && selectedFileIds.size > 0"
+             class="flex items-center gap-3 mb-4 px-4 py-3 bg-blue-50 border border-blue-200 rounded-xl">
+          <span class="text-sm text-blue-800 font-medium"
+                x-text="selectedFileIds.size + ' file' + (selectedFileIds.size === 1 ? '' : 's') + ' selected'"></span>
+          <button @click="bulkTrashSelected()"
+                  class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-red-600 hover:bg-red-500 text-white text-sm font-medium transition-colors">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+            </svg>
+            Move to Trash
+          </button>
+          <button @click="selectedFileIds = new Set()" class="text-sm text-blue-600 hover:underline">Clear selection</button>
         </div>
 
         <!-- Active filter chips -->
@@ -321,6 +349,10 @@
           <table class="w-full text-sm">
             <thead class="bg-gray-50 border-b border-gray-200">
               <tr>
+                <th x-show="filesSelecting" class="px-3 py-3 w-8">
+                  <input type="checkbox" :checked="allPageSelected" @change="toggleSelectAll()"
+                    class="rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
+                </th>
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Name</th>
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Type</th>
                 <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wide">Size</th>
@@ -331,7 +363,14 @@
             </thead>
             <tbody class="divide-y divide-gray-100">
               <template x-for="(f, idx) in files" :key="f.id">
-                <tr class="hover:bg-gray-50 transition-colors cursor-pointer" @click="openViewer(f, idx)">
+                <tr class="hover:bg-gray-50 transition-colors cursor-pointer"
+                    :class="isFileSelected(f.id) ? 'bg-blue-50' : ''"
+                    @click="filesSelecting ? toggleFileSelect(f.id) : openViewer(f, idx)">
+                  <td x-show="filesSelecting" class="px-3 py-3 w-8" @click.stop="toggleFileSelect(f.id)">
+                    <input type="checkbox" :checked="isFileSelected(f.id)"
+                      @change="toggleFileSelect(f.id)"
+                      class="rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
+                  </td>
                   <td class="px-4 py-3 font-medium truncate max-w-xs" x-text="f.file_name"></td>
                   <td class="px-4 py-3">
                     <span class="inline-flex items-center gap-1">
@@ -361,10 +400,10 @@
                 </tr>
               </template>
               <tr x-show="files.length === 0 && !filesLoading">
-                <td colspan="6" class="px-4 py-12 text-center text-gray-400">No files found</td>
+                <td colspan="7" class="px-4 py-12 text-center text-gray-400">No files found</td>
               </tr>
               <tr x-show="filesLoading">
-                <td colspan="6" class="px-4 py-12 text-center text-gray-400">
+                <td colspan="7" class="px-4 py-12 text-center text-gray-400">
                   <div class="flex items-center justify-center gap-2">
                     <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
                       <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
@@ -382,8 +421,17 @@
         <div x-show="viewMode === 'grid'">
           <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
             <template x-for="(f, idx) in files" :key="f.id">
-              <div class="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden hover:shadow-md hover:border-blue-200 transition-all group cursor-pointer"
-                   @click="openViewer(f, idx)">
+              <div class="relative bg-white rounded-xl border shadow-sm overflow-hidden hover:shadow-md transition-all group cursor-pointer"
+                   :class="isFileSelected(f.id) ? 'border-blue-400 ring-2 ring-blue-300' : 'border-gray-200 hover:border-blue-200'"
+                   @click="filesSelecting ? toggleFileSelect(f.id) : openViewer(f, idx)">
+                <!-- Selection checkbox overlay -->
+                <div x-show="filesSelecting"
+                     class="absolute top-2 left-2 z-10"
+                     @click.stop="toggleFileSelect(f.id)">
+                  <input type="checkbox" :checked="isFileSelected(f.id)"
+                    @change="toggleFileSelect(f.id)"
+                    class="rounded border-gray-300 text-blue-600 focus:ring-blue-500 shadow" />
+                </div>
                 <!-- Thumbnail for images, extension icon for others -->
                 <div class="aspect-square flex items-center justify-center overflow-hidden"
                      :style="isImageExt(f.extension) && !thumbErrors[f.id] ? '' : 'background:' + extColor(f.extension) + '18; color:' + extColor(f.extension)">

--- a/internal/webui/web/static/app.js
+++ b/internal/webui/web/static/app.js
@@ -34,6 +34,9 @@ document.addEventListener('alpine:init', () => {
     filesSort:    'mod_time',
     filesOrder:   'desc',
     viewMode:     'list',
+    // Selection mode
+    filesSelecting:  false,
+    selectedFileIds: new Set(),
 
     // ── History log ──────────────────────────────────────────────────────────
     history:             [],
@@ -237,6 +240,7 @@ document.addEventListener('alpine:init', () => {
 
     async loadFiles() {
       this.filesLoading = true;
+      this.selectedFileIds = new Set();
       try {
         const p = new URLSearchParams({
           page:     this.filesPage,
@@ -833,6 +837,56 @@ document.addEventListener('alpine:init', () => {
     },
 
     // ── Trash page ────────────────────────────────────────────────────────────
+    // ── File selection & bulk trash ───────────────────────────────────────────
+    toggleSelectMode() {
+      this.filesSelecting = !this.filesSelecting;
+      if (!this.filesSelecting) this.selectedFileIds = new Set();
+    },
+
+    toggleFileSelect(id) {
+      const s = new Set(this.selectedFileIds);
+      if (s.has(id)) { s.delete(id); } else { s.add(id); }
+      this.selectedFileIds = s;
+    },
+
+    isFileSelected(id) {
+      return this.selectedFileIds.has(id);
+    },
+
+    get allPageSelected() {
+      return this.files.length > 0 && this.files.every(f => this.selectedFileIds.has(f.id));
+    },
+
+    toggleSelectAll() {
+      if (this.allPageSelected) {
+        this.selectedFileIds = new Set();
+      } else {
+        this.selectedFileIds = new Set(this.files.map(f => f.id));
+      }
+    },
+
+    async bulkTrashSelected() {
+      if (this.selectedFileIds.size === 0) return;
+      const ids = [...this.selectedFileIds];
+      const res = await fetch('/api/files/bulk-trash', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids, confirm: true }),
+      });
+      const j = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        this.showToast('Error: ' + (j.error || res.status));
+        return;
+      }
+      const count = j.trashed ?? 0;
+      this.showToast(`Moved ${count} file${count === 1 ? '' : 's'} to Trash`);
+      this.selectedFileIds = new Set();
+      this.filesSelecting = false;
+      await this.loadFiles();
+      this.loadStats();
+      this.loadNavData();
+    },
+
     async loadTrash() {
       this.trashLoading = true;
       try {


### PR DESCRIPTION
- New POST /api/files/bulk-trash endpoint (up to 500 files per request)
- Select toggle button in Files filter bar to enter selection mode
- List view: checkbox column with select-all header checkbox
- Grid view: checkbox overlay on each card with blue selection ring
- Bulk action bar appears when files are selected showing count and Move to Trash button
- Row clicks open the viewer normally; in selection mode they toggle selection
- Selection clears on page/filter changes and after bulk action completes
- Audit log entries written for each file in a bulk operation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Files page selection mode for choosing multiple files in list or grid view.
  * Added select-all, clear-selection, and selected-item count controls.
  * Added a bulk action to move selected files to Trash.
  * Added confirmation and validation for bulk Trash actions, with per-file error reporting.
  * Bulk actions are unavailable when the server is in read-only mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->