### PR TITLE
add manualy proxy re-generate

### DIFF
--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -144,6 +144,44 @@ func handleBulkTrashFiles(cfg Config) http.HandlerFunc {
 	}
 }
 
+// handleRegenerateProxy resets a file's proxy status to 'pending' and deletes
+// any existing proxy file on disk so the worker will regenerate it.
+func handleRegenerateProxy(cfg Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id, err := parseID(r)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid file id")
+			return
+		}
+
+		file, err := db.GetFile(cfg.DB, id)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if file == nil {
+			writeError(w, http.StatusNotFound, "file not found")
+			return
+		}
+
+		// Delete the existing proxy file from disk if present.
+		if file.ProxyPath != "" {
+			if removeErr := os.Remove(file.ProxyPath); removeErr != nil && !os.IsNotExist(removeErr) {
+				writeError(w, http.StatusInternalServerError, "failed to remove proxy file: "+removeErr.Error())
+				return
+			}
+		}
+
+		// Reset proxy status to pending so the worker picks it up.
+		if err := db.ResetFileProxy(cfg.DB, id); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]string{"status": "pending"})
+	}
+}
+
 // writeJSON serialises v as JSON with the given status code.
 func writeJSON(w http.ResponseWriter, status int, v interface{}) {
 	w.WriteHeader(status)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -51,6 +51,7 @@ func NewRouter(cfg Config) http.Handler {
 			r.Get("/{id}/history", handleGetFileHistory(cfg))
 			r.Get("/{id}/tags", handleGetFileTags(cfg))
 			r.Put("/{id}/tags", readonlyGuard(cfg, handleSetFileTags(cfg)))
+			r.Post("/{id}/regenerate-proxy", readonlyGuard(cfg, handleRegenerateProxy(cfg)))
 		})
 
 		r.Route("/duplicates", func(r chi.Router) {

--- a/internal/db/proxy.go
+++ b/internal/db/proxy.go
@@ -259,6 +259,19 @@ func ResetSkippedProxies(db *sql.DB) error {
 	return err
 }
 
+// ResetFileProxy resets a single file's proxy columns back to pending so the
+// worker will regenerate it. The caller is responsible for deleting the old
+// proxy file on disk before calling this.
+func ResetFileProxy(db *sql.DB, fileID int64) error {
+	_, err := db.Exec(
+		`UPDATE file_registry
+		 SET proxy_status = ?, proxy_path = NULL, proxy_error = NULL, proxy_generated_at = NULL
+		 WHERE id = ?`,
+		ProxyStatusPending, fileID,
+	)
+	return err
+}
+
 // ResetProcessingProxies resets any stale 'processing' rows (left over from
 // an unclean shutdown) back to 'pending'.
 func ResetProcessingProxies(db *sql.DB) error {

--- a/internal/proxy/image.go
+++ b/internal/proxy/image.go
@@ -40,7 +40,14 @@ func convertRaw(srcPath, proxyPath string, cfg ImageConfig) error {
 	dcrawCmd := exec.Command("nice", "-n", "19",
 		"dcraw", "-c", "-w", "-T", srcPath)
 	convertCmd := exec.Command("nice", "-n", "19",
-		"convert", "-", "-resize", resizeArg, "-quality", qualityArg, "-auto-orient", proxyPath)
+		"convert", "-",
+		"-resize", resizeArg,
+		"-colorspace", "sRGB",
+		"-depth", "8",
+		"-strip",
+		"-quality", qualityArg,
+		"-auto-orient",
+		proxyPath)
 
 	pipe, err := dcrawCmd.StdoutPipe()
 	if err != nil {
@@ -69,6 +76,8 @@ func convertRaw(srcPath, proxyPath string, cfg ImageConfig) error {
 }
 
 // convertStandard uses ImageMagick to convert a standard image to a JPEG proxy.
+// Flags ensure browser-safe output: sRGB color space, 8-bit depth, stripped
+// metadata, and correct orientation applied from EXIF.
 func convertStandard(srcPath, proxyPath string, cfg ImageConfig) error {
 	resizeArg := resizeGeometry(cfg.MaxWidth)
 	qualityArg := fmt.Sprintf("%d", cfg.Quality)
@@ -77,8 +86,11 @@ func convertStandard(srcPath, proxyPath string, cfg ImageConfig) error {
 	cmd := exec.Command("nice", "-n", "19",
 		"convert", srcPath+"[0]",
 		"-resize", resizeArg,
+		"-auto-orient",          // apply EXIF rotation so browsers see it upright
+		"-colorspace", "sRGB",   // normalise to sRGB — browsers can't handle CMYK or wide-gamut
+		"-depth", "8",           // force 8-bit — browsers don't support 16-bit JPEG
+		"-strip",                // remove ICC profiles, EXIF, XMP — reduces size, avoids colour-shift quirks
 		"-quality", qualityArg,
-		"-auto-orient",
 		proxyPath,
 	)
 	out, err := cmd.CombinedOutput()

--- a/internal/proxy/video.go
+++ b/internal/proxy/video.go
@@ -16,7 +16,8 @@ type VideoConfig struct {
 }
 
 // ConvertVideo generates an H.264 MP4 proxy for the given source video.
-// Returns the path to the generated proxy file.
+// Output is always browser-compatible: H.264 High profile, yuv420p, AAC audio,
+// faststart MP4. These constraints ensure playback in all modern browsers.
 func ConvertVideo(srcPath, proxyPath string, cfg VideoConfig) error {
 	if err := os.MkdirAll(filepath.Dir(proxyPath), 0755); err != nil {
 		return fmt.Errorf("create proxy dir: %w", err)
@@ -31,15 +32,17 @@ func ConvertVideo(srcPath, proxyPath string, cfg VideoConfig) error {
 		crf = 28
 	}
 
-	// Scale filter: limit width to maxW while preserving aspect ratio;
-	// height must be divisible by 2 (H.264 requirement).
-	scaleFilter := fmt.Sprintf("scale='min(%d,iw)':'-2'", maxW)
+	// Combine scale + pixel-format conversion in one filter chain.
+	// format=yuv420p is mandatory for H.264 browser playback — professional
+	// sources (DNXHR, ProRes, etc.) use yuv422p or 10-bit which browsers reject.
+	// scale uses trunc to guarantee width/height divisible by 2 (H.264 requirement).
+	vf := fmt.Sprintf("scale=trunc(min(%d\\,iw)/2)*2:-2,format=yuv420p", maxW)
 
 	var args []string
 	if cfg.UseGPU {
-		args = buildGPUArgs(srcPath, proxyPath, scaleFilter, crf)
+		args = buildGPUArgs(srcPath, proxyPath, vf, crf)
 	} else {
-		args = buildCPUArgs(srcPath, proxyPath, scaleFilter, crf)
+		args = buildCPUArgs(srcPath, proxyPath, vf, crf)
 	}
 
 	cmd := exec.Command("nice", append([]string{"-n", "19", "ffmpeg"}, args...)...)
@@ -50,29 +53,37 @@ func ConvertVideo(srcPath, proxyPath string, cfg VideoConfig) error {
 	return nil
 }
 
-func buildCPUArgs(src, dst, scaleFilter string, crf int) []string {
+func buildCPUArgs(src, dst, vf string, crf int) []string {
 	return []string{
 		"-i", src,
-		"-vf", scaleFilter,
+		"-vf", vf,
 		"-c:v", "libx264",
+		"-profile:v", "high",   // H.264 High profile — universally supported
+		"-level", "4.0",        // compatible with all modern browsers and devices
 		"-crf", fmt.Sprintf("%d", crf),
 		"-preset", "fast",
+		// Audio: re-encode to stereo AAC; -ac 2 handles mono/multichannel sources.
+		// If the source has no audio stream this is silently ignored by ffmpeg.
 		"-c:a", "aac",
 		"-b:a", "128k",
-		"-movflags", "+faststart",
+		"-ac", "2",
+		"-movflags", "+faststart", // moov atom first — essential for browser streaming
 		"-y", dst,
 	}
 }
 
-func buildGPUArgs(src, dst, scaleFilter string, crf int) []string {
+func buildGPUArgs(src, dst, vf string, crf int) []string {
 	return []string{
 		"-i", src,
-		"-vf", scaleFilter,
+		"-vf", vf,
 		"-c:v", "h264_nvenc",
+		"-profile:v", "high",
+		"-level", "4.0",
 		"-cq", fmt.Sprintf("%d", crf),
 		"-preset", "fast",
 		"-c:a", "aac",
 		"-b:a", "128k",
+		"-ac", "2",
 		"-movflags", "+faststart",
 		"-y", dst,
 	}

--- a/internal/webui/web/index.html
+++ b/internal/webui/web/index.html
@@ -1998,6 +1998,38 @@
                 </svg>
                 Move to Trash
               </button>
+
+              <!-- Regenerate proxy — only shown when a proxy is applicable -->
+              <template x-if="viewerFile && viewerFile.proxy_status">
+                <div class="border-t border-white/10 pt-4">
+                  <div class="bg-white/5 border border-white/10 rounded-lg p-3 mb-3">
+                    <p class="text-white/70 text-xs leading-relaxed">
+                      Regenerate proxy deletes the existing proxy file (if any) and
+                      re-queues this file for conversion with the current settings.
+                      Current status:
+                      <span class="font-medium"
+                        :class="{
+                          'text-green-400':  viewerFile.proxy_status === 'done',
+                          'text-blue-400':   viewerFile.proxy_status === 'pending' || viewerFile.proxy_status === 'processing',
+                          'text-red-400':    viewerFile.proxy_status === 'failed',
+                          'text-gray-400':   viewerFile.proxy_status === 'skipped'
+                        }"
+                        x-text="viewerFile.proxy_status">
+                      </span>
+                    </p>
+                  </div>
+                  <button @click="regenViewerProxy()"
+                          :disabled="(serverSettings && serverSettings.readonly) || viewerFile.proxy_status === 'processing'"
+                          class="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-blue-600 hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-medium transition-colors">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                        d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+                    </svg>
+                    <span x-text="viewerFile.proxy_status === 'processing' ? 'Converting…' : 'Regenerate Proxy'"></span>
+                  </button>
+                </div>
+              </template>
+
               <template x-if="serverSettings && serverSettings.readonly">
                 <p class="text-white/30 text-xs text-center">Server is in read-only mode</p>
               </template>

--- a/internal/webui/web/static/app.js
+++ b/internal/webui/web/static/app.js
@@ -981,6 +981,26 @@ document.addEventListener('alpine:init', () => {
       this.loadNavData();
     },
 
+    async regenViewerProxy() {
+      if (!this.viewerFile) return;
+      const id = this.viewerFile.id;
+      const res = await fetch(`/api/files/${id}/regenerate-proxy`, { method: 'POST' });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        this.showToast('Error: ' + (j.error || res.status));
+        return;
+      }
+      // Refresh the viewer file so the proxy status badge updates immediately.
+      const fileRes = await fetch(`/api/files/${id}`);
+      if (fileRes.ok) {
+        const updated = await fileRes.json();
+        this.viewerFile = updated;
+        const idx = this.files.findIndex(f => f.id === id);
+        if (idx !== -1) this.files[idx] = updated;
+      }
+      this.showToast('Proxy queued for regeneration');
+    },
+
     async restoreTrashFile(file) {
       const res = await fetch(`/api/trash/${file.id}/restore`, { method: 'POST' });
       if (!res.ok) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to regenerate a file’s proxy from the Media Viewer.
  * Proxy status updates immediately after regeneration is queued, with success or error notifications.
  * Regeneration is unavailable while processing or when the server is read-only.
  * Improved browser compatibility for generated images and videos through standardised formats, orientation, colour, and playback settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->