### PR TITLE
Fix Files tab: individual checkboxes not selectable/deselectable

### DIFF
--- a/internal/webui/web/index.html
+++ b/internal/webui/web/index.html
@@ -368,6 +368,7 @@
                     @click="filesSelecting ? toggleFileSelect(f.id) : openViewer(f, idx)">
                   <td x-show="filesSelecting" class="px-3 py-3 w-8" @click.stop="toggleFileSelect(f.id)">
                     <input type="checkbox" :checked="isFileSelected(f.id)"
+                      @click.stop
                       @change="toggleFileSelect(f.id)"
                       class="rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
                   </td>
@@ -429,6 +430,7 @@
                      class="absolute top-2 left-2 z-10"
                      @click.stop="toggleFileSelect(f.id)">
                   <input type="checkbox" :checked="isFileSelected(f.id)"
+                    @click.stop
                     @change="toggleFileSelect(f.id)"
                     class="rounded border-gray-300 text-blue-600 focus:ring-blue-500 shadow" />
                 </div>


### PR DESCRIPTION
Root cause: clicking a checkbox fired toggleFileSelect twice — once from @change on the <input> and once from @click.stop on the parent <td>/<div>. The two calls cancelled each other out, leaving the checkbox state unchanged.

Fix: add @click.stop to the <input> in both list and grid views so the input's click event does not bubble to the parent handler. @change on the input remains the sole source of truth for toggling.