### PR TITLE
Add proxy summary to dashboard and proxy filter to Files tab

### DIFF
--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -27,6 +27,7 @@ func handleListFiles(cfg Config) http.HandlerFunc {
 			Year:           q.Get("year"),
 			Month:          q.Get("month"),
 			DuplicatesOnly: q.Get("duplicates_only") == "true" || q.Get("duplicates_only") == "1",
+			ProxyFilter:    q.Get("proxy"),
 			Page:           page,
 			PerPage:        perPage,
 			Sort:           q.Get("sort"),

--- a/internal/db/files.go
+++ b/internal/db/files.go
@@ -37,6 +37,7 @@ type FileListParams struct {
 	Year           string // 4-digit year, e.g. "2024"
 	Month          string // 2-digit month, e.g. "01" (requires Year to be set)
 	DuplicatesOnly bool
+	ProxyFilter    string // "done" = has proxy | "none" = no proxy yet
 	Page           int
 	PerPage        int
 	Sort           string
@@ -197,6 +198,13 @@ func buildWhereClause(p FileListParams) (string, []interface{}) {
 
 	if p.DuplicatesOnly {
 		conditions = append(conditions, `fr.archive_path LIKE '%/_duplicates/%'`)
+	}
+
+	switch p.ProxyFilter {
+	case "done":
+		conditions = append(conditions, `fr.proxy_status = 'done'`)
+	case "none":
+		conditions = append(conditions, `(fr.proxy_status IS NULL OR fr.proxy_status IN ('pending','processing','failed','skipped'))`)
 	}
 
 	// Always exclude trashed files from the regular file list.

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -17,6 +17,10 @@ type Stats struct {
 	TotalSizeHuman  string     `json:"total_size_human"`
 	TaggedFiles     int64      `json:"tagged_files"`
 	Extensions      []ExtStat  `json:"extensions"`
+	ProxyDone       int64      `json:"proxy_done"`
+	ProxyPending    int64      `json:"proxy_pending"`    // pending + processing
+	ProxyFailed     int64      `json:"proxy_failed"`
+	ProxyConverting bool       `json:"proxy_converting"` // true if any row is 'processing'
 }
 
 // ExtStat is per-extension aggregate data.
@@ -77,6 +81,34 @@ func GetStats(database *sql.DB) (*Stats, error) {
 	})
 	if len(stats.Extensions) > 20 {
 		stats.Extensions = stats.Extensions[:20]
+	}
+
+	// Proxy summary counts for the dashboard.
+	proxyRows, err := database.Query(`
+		SELECT proxy_status, COUNT(*)
+		FROM   file_registry
+		WHERE  trashed_at IS NULL AND proxy_status IS NOT NULL
+		GROUP  BY proxy_status
+	`)
+	if err == nil {
+		defer proxyRows.Close()
+		for proxyRows.Next() {
+			var status string
+			var count int64
+			if err := proxyRows.Scan(&status, &count); err == nil {
+				switch status {
+				case "done":
+					stats.ProxyDone = count
+				case "pending":
+					stats.ProxyPending += count
+				case "processing":
+					stats.ProxyPending += count
+					stats.ProxyConverting = true
+				case "failed":
+					stats.ProxyFailed = count
+				}
+			}
+		}
 	}
 
 	return stats, nil

--- a/internal/webui/web/index.html
+++ b/internal/webui/web/index.html
@@ -51,7 +51,7 @@
 
       <!-- All Files -->
       <button class="sidebar-link w-full text-left"
-        :class="!filterExt && !filterYear && !filterTag && !filterDuplicates && !filesQuery ? 'active' : ''"
+        :class="!filterExt && !filterYear && !filterTag && !filterDuplicates && !filterProxy && !filesQuery ? 'active' : ''"
         @click="clearAllFilters(); page='files'">
         <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7h18M3 12h18M3 17h18"/>
@@ -201,6 +201,53 @@
           </div>
         </div>
 
+        <!-- Proxy summary card -->
+        <div class="bg-white rounded-xl border border-gray-200 p-5 shadow-sm mb-8" x-show="stats && (stats.proxy_done > 0 || stats.proxy_pending > 0 || stats.proxy_failed > 0)">
+          <div class="flex items-center justify-between mb-3">
+            <h2 class="text-base font-semibold text-gray-800">Proxy Generation</h2>
+            <!-- Live converting indicator -->
+            <template x-if="stats?.proxy_converting">
+              <span class="inline-flex items-center gap-1.5 text-xs font-medium text-green-700 bg-green-50 border border-green-200 px-2.5 py-1 rounded-full">
+                <span class="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse inline-block"></span>
+                Converting now
+              </span>
+            </template>
+            <template x-if="!stats?.proxy_converting && stats?.proxy_pending > 0">
+              <span class="inline-flex items-center gap-1.5 text-xs font-medium text-blue-700 bg-blue-50 border border-blue-200 px-2.5 py-1 rounded-full">
+                <span class="w-1.5 h-1.5 rounded-full bg-blue-400 inline-block"></span>
+                Queued
+              </span>
+            </template>
+            <template x-if="!stats?.proxy_converting && stats?.proxy_pending === 0 && stats?.proxy_done > 0">
+              <span class="inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 bg-gray-50 border border-gray-200 px-2.5 py-1 rounded-full">
+                <span class="w-1.5 h-1.5 rounded-full bg-gray-400 inline-block"></span>
+                Idle
+              </span>
+            </template>
+          </div>
+          <div class="grid grid-cols-3 gap-3">
+            <button @click="setFilter('proxy-done'); page='files'"
+              class="text-center p-3 rounded-lg bg-green-50 hover:bg-green-100 border border-green-100 transition-colors cursor-pointer group">
+              <p class="text-2xl font-bold text-green-700 group-hover:text-green-800"
+                 x-text="stats?.proxy_done?.toLocaleString() ?? '—'"></p>
+              <p class="text-xs text-green-600 mt-0.5">Proxies ready</p>
+            </button>
+            <button @click="setFilter('proxy-none'); page='files'"
+              class="text-center p-3 rounded-lg bg-blue-50 hover:bg-blue-100 border border-blue-100 transition-colors cursor-pointer group">
+              <p class="text-2xl font-bold text-blue-700 group-hover:text-blue-800"
+                 x-text="stats?.proxy_pending?.toLocaleString() ?? '—'"></p>
+              <p class="text-xs text-blue-600 mt-0.5">Pending / converting</p>
+            </button>
+            <div class="text-center p-3 rounded-lg bg-red-50 border border-red-100"
+                 :class="(stats?.proxy_failed ?? 0) > 0 ? 'cursor-pointer hover:bg-red-100' : ''"
+                 @click="(stats?.proxy_failed ?? 0) > 0 && (page='settings')">
+              <p class="text-2xl font-bold text-red-600"
+                 x-text="stats?.proxy_failed?.toLocaleString() ?? '—'"></p>
+              <p class="text-xs text-red-500 mt-0.5">Failed</p>
+            </div>
+          </div>
+        </div>
+
         <!-- File-type breakdown -->
         <div class="bg-white rounded-xl border border-gray-200 p-6 mb-8 shadow-sm" x-show="stats?.extensions?.length">
           <h2 class="text-base font-semibold mb-4">File Types</h2>
@@ -279,6 +326,14 @@
             class="border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500">
             <option value="desc">Newest first</option>
             <option value="asc">Oldest first</option>
+          </select>
+
+          <!-- Proxy filter -->
+          <select x-model="filterProxy"
+            class="border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+            <option value="">All files</option>
+            <option value="done">✓ Proxy ready</option>
+            <option value="none">⏳ No proxy yet</option>
           </select>
 
           <!-- View mode toggle -->

--- a/internal/webui/web/static/app.js
+++ b/internal/webui/web/static/app.js
@@ -20,6 +20,7 @@ document.addEventListener('alpine:init', () => {
     filterMonth:      '',
     filterTag:        '',
     filterDuplicates: false,
+    filterProxy:      '',   // '' | 'done' | 'none'
 
     // ── Dashboard data ───────────────────────────────────────────────────────
     stats:         null,
@@ -147,6 +148,10 @@ document.addEventListener('alpine:init', () => {
         c.push({ label: this.filterTag,                            key: 'tag' });
       if (this.filterDuplicates)
         c.push({ label: 'duplicates only',                         key: 'duplicates' });
+      if (this.filterProxy === 'done')
+        c.push({ label: '✓ proxy ready',                           key: 'proxy' });
+      if (this.filterProxy === 'none')
+        c.push({ label: '⏳ no proxy yet',                         key: 'proxy' });
       return c;
     },
 
@@ -190,6 +195,7 @@ document.addEventListener('alpine:init', () => {
       this.$watch('filesQuery', () => { this.filesPage = 1; this.loadFiles(); });
       this.$watch('filesSort',  () => { this.filesPage = 1; this.loadFiles(); });
       this.$watch('filesOrder', () => { this.filesPage = 1; this.loadFiles(); });
+      this.$watch('filterProxy',() => { this.filesPage = 1; this.loadFiles(); });
 
       this.$watch('historyPage', () => this.loadHistory());
       this.$watch('historyStatusFilter',  () => { this.historyPage = 1; this.loadHistory(); });
@@ -258,6 +264,7 @@ document.addEventListener('alpine:init', () => {
         if (this.filterMonth)      p.set('month',          this.filterMonth);
         if (this.filterTag)        p.set('tag',            this.filterTag);
         if (this.filterDuplicates) p.set('duplicates_only','true');
+        if (this.filterProxy)      p.set('proxy', this.filterProxy);
 
         const res = await fetch('/api/files?' + p);
         this.filesResult = await res.json();
@@ -337,6 +344,7 @@ document.addEventListener('alpine:init', () => {
       this.filterMonth      = '';
       this.filterTag        = '';
       this.filterDuplicates = false;
+      this.filterProxy      = '';
       this.filesQuery       = '';
       this.filesPage        = 1;
 
@@ -346,6 +354,8 @@ document.addEventListener('alpine:init', () => {
         case 'month':      this.filterYear = val; this.filterMonth = val2; break;
         case 'tag':        this.filterTag        = val;  break;
         case 'duplicates': this.filterDuplicates = true; break;
+        case 'proxy-done': this.filterProxy      = 'done'; break;
+        case 'proxy-none': this.filterProxy      = 'none'; break;
       }
       this.page = 'files';
       this.loadFiles();
@@ -358,6 +368,7 @@ document.addEventListener('alpine:init', () => {
         case 'month':      this.filterMonth      = ''; break;
         case 'tag':        this.filterTag        = ''; break;
         case 'duplicates': this.filterDuplicates = false; break;
+        case 'proxy':      this.filterProxy      = ''; break;
       }
       this.filesPage = 1;
       this.loadFiles();
@@ -365,7 +376,7 @@ document.addEventListener('alpine:init', () => {
 
     clearAllFilters() {
       this.filterExt = ''; this.filterYear = ''; this.filterMonth = '';
-      this.filterTag = ''; this.filterDuplicates = false;
+      this.filterTag = ''; this.filterDuplicates = false; this.filterProxy = '';
       this.filesQuery = ''; this.filesPage = 1;
       this.loadFiles();
     },


### PR DESCRIPTION
Dashboard:
- New 'Proxy Generation' card shown once proxy activity exists
- 3 count tiles: Proxies ready (green), Pending/converting (blue), Failed (red)
- Live 'Converting now' pill with pulsing dot when any file is processing
- 'Queued' pill when files are pending but worker is idle
- Clicking green/blue tiles navigates to Files tab with matching filter applied
- Clicking red tile navigates to Settings for retry

Files tab:
- New 'Proxy' dropdown filter in filter bar: All files | ✓ Proxy ready | ⏳ No proxy yet
- Filter drives a new ProxyFilter field on FileListParams / buildWhereClause
  - 'done'  → WHERE proxy_status = 'done'
  - 'none'  → WHERE proxy_status IS NULL OR proxy_status IN (pending, processing, failed, skipped)
- Active filter shows as a chip (✓ proxy ready / ⏳ no proxy yet) with × to clear
-  on filterProxy resets page and reloads

Backend:
- Stats struct gains ProxyDone, ProxyPending, ProxyFailed, ProxyConverting fields
- GetStats queries proxy_status counts from file_registry
- FileListParams gains ProxyFilter; buildWhereClause handles it
- /api/files accepts ?proxy=done|none query param