### PR TITLE
Fix CR3 proxy conversion and add proxy path to Info tab

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -23,9 +23,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       dcraw \
       libraw-bin \
     && rm -rf /var/lib/apt/lists/* \
-    # libraw-bin provides dcraw_emu — symlink as 'dcraw' fallback if package dcraw absent
-    && (which dcraw > /dev/null 2>&1 || \
-        (which dcraw_emu > /dev/null 2>&1 && ln -s "$(which dcraw_emu)" /usr/local/bin/dcraw)) \
+    # Always prefer dcraw_emu (libraw-bin) over the older dcraw — dcraw_emu supports CR3
+    # Use -sf to force-overwrite the system dcraw if present
+    && (which dcraw_emu > /dev/null 2>&1 && ln -sf "$(which dcraw_emu)" /usr/local/bin/dcraw) \
     || true
 
 # Create non-root user

--- a/internal/proxy/image.go
+++ b/internal/proxy/image.go
@@ -30,15 +30,24 @@ func ConvertImage(srcPath, proxyPath string, cfg ImageConfig) error {
 	return convertStandard(srcPath, proxyPath, cfg)
 }
 
-// convertRaw uses dcraw to demosaic the RAW file and pipes the TIFF output
-// into ImageMagick for resizing and JPEG encoding.
+// dcrawBin returns the best available RAW decoder.
+// dcraw_emu (from libraw) supports newer formats such as CR3; prefer it when present.
+func dcrawBin() string {
+	if _, err := exec.LookPath("dcraw_emu"); err == nil {
+		return "dcraw_emu"
+	}
+	return "dcraw"
+}
+
+// convertRaw uses dcraw/dcraw_emu to demosaic the RAW file and pipes the TIFF
+// output into ImageMagick for resizing and JPEG encoding.
 func convertRaw(srcPath, proxyPath string, cfg ImageConfig) error {
 	resizeArg := resizeGeometry(cfg.MaxWidth)
 	qualityArg := fmt.Sprintf("%d", cfg.Quality)
 
-	// dcraw -c : write to stdout, -w : use camera white balance, -T : TIFF output
+	// -c : write to stdout, -w : camera white balance, -T : TIFF output
 	dcrawCmd := exec.Command("nice", "-n", "19",
-		"dcraw", "-c", "-w", "-T", srcPath)
+		dcrawBin(), "-c", "-w", "-T", srcPath)
 	convertCmd := exec.Command("nice", "-n", "19",
 		"convert", "-",
 		"-resize", resizeArg,

--- a/internal/webui/web/index.html
+++ b/internal/webui/web/index.html
@@ -1958,6 +1958,20 @@
                   (check Settings → Proxy Generation)
                 </span>
               </div>
+              <template x-if="viewerFile.proxy_status === 'done' && viewerFile.proxy_path">
+                <div>
+                  <p class="text-white/40 text-xs uppercase tracking-wide mb-1">Proxy path</p>
+                  <p class="break-all font-mono text-xs text-white/50" x-text="viewerFile.proxy_path"></p>
+                  <a :href="'/api/files/' + viewerFile.id + '/proxy'" target="_blank" rel="noopener"
+                     class="inline-flex items-center gap-1 mt-1.5 text-xs text-blue-400 hover:text-blue-300 transition-colors">
+                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                            d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+                    </svg>
+                    Open proxy in new tab
+                  </a>
+                </div>
+              </template>
 
               <!-- ── Tags editor ── -->
               <div>


### PR DESCRIPTION
CR3 conversion fix:
- Dockerfile.web: always symlink dcraw_emu -> /usr/local/bin/dcraw using -sf (force-overwrite). Previously only created the symlink when the system dcraw was absent; on Debian bookworm dcraw IS present but does not support Canon CR3 format — dcraw_emu (libraw) supports CR3, CR2, DNG and all other RAW formats.
- internal/proxy/image.go: add dcrawBin() helper that prefers dcraw_emu at runtime, falls back to dcraw. This is defence-in-depth: if the symlink is somehow absent in a custom deployment, the correct binary is still used.

Info tab proxy path:
- Show 'Proxy path' row in File viewer Info tab when proxy_status == 'done'
- Displays the on-disk proxy path as monospace text for easy debugging
- Includes an 'Open proxy in new tab' link → GET /api/files/{id}/proxy so the user can verify the proxy file renders correctly in the browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added proxy details to the media viewer’s Info sidebar, including the proxy path and an option to open the proxy in a new tab.

- **Bug Fixes**
  - Improved RAW image conversion by selecting the most suitable available decoder, increasing compatibility with newer RAW formats.
  - Improved reliability when generating and accessing RAW image previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->