### PR TITLE
Fix viewer not using proxy for unsupported native formats (CR2, CR3, …

### DIFF
--- a/internal/webui/web/static/app.js
+++ b/internal/webui/web/static/app.js
@@ -167,7 +167,15 @@ document.addEventListener('alpine:init', () => {
 
     get viewerType() {
       if (!this.viewerFile) return 'other';
-      return this.viewerTypeForExt(this.viewerFile.extension || '');
+      const native = this.viewerTypeForExt(this.viewerFile.extension || '');
+      // If the native format isn't previewable but a proxy exists, derive the
+      // viewer type from the proxy extension instead.
+      // e.g. CR2 → _proxy.jpg → 'image', DNXHR .mov → _proxy.mp4 → 'video'
+      if (native === 'other' && this.viewerFile.proxy_status === 'done' && this.viewerFile.proxy_path) {
+        const proxyExt = (this.viewerFile.proxy_path.split('.').pop() || '').toLowerCase();
+        return this.viewerTypeForExt(proxyExt);
+      }
+      return native;
     },
 
     // ── Lifecycle ────────────────────────────────────────────────────────────


### PR DESCRIPTION
…DNG, etc.)

The viewerType getter only checked the original file extension, so CR2/CR3/DNG files (extension not in the image whitelist) always fell through to 'other' and showed 'Preview not available...' — even when a proxy.jpg had been generated.

Fix: after computing the native type, if it is 'other' and a done proxy exists, derive the viewer type from the proxy file extension instead:
  CR2 → _proxy.jpg → viewerTypeForExt('jpg') → 'image'  ✓
  .mov/DNXHR → _proxy.mp4 → viewerTypeForExt('mp4') → 'video'  ✓

The image template already uses bestMediaURL() which returns the proxy URL when proxy_status === 'done', so once viewerType resolves to 'image' the proxy is displayed automatically and the 'proxy' badge is shown.