### PR TITLE
re-scan dupes

### DIFF
--- a/internal/api/duplicates.go
+++ b/internal/api/duplicates.go
@@ -237,18 +237,25 @@ func handleBulkDeleteIdentical(cfg Config) http.HandlerFunc {
 // helpers
 // ──────────────────────────────────────────────────────────────────────────────
 
-// handleRescanDuplicates performs a full checksum-based re-scan of the archive:
-//   - Orphaned _duplicates/ entries (unique checksum, no primary) → promoted to
+// handleRescanDuplicates performs a full fingerprint-based re-scan of the archive:
+//   - Orphaned _duplicates/ entries (unique content, no primary) → promoted to
 //     their derived primary path.
-//   - Multiple primary-path files with the same checksum → the extras are moved
+//   - Multiple primary-path files sharing the same fingerprint → extras are moved
 //     into a _duplicates/ subdirectory alongside the canonical primary.
 //
+// The proxy worker is paused for the duration of the rescan to reduce system load.
 // Requires confirm=true query param as a safety guard.
 func handleRescanDuplicates(cfg Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("confirm") != "true" {
 			writeError(w, http.StatusBadRequest, "confirm=true is required")
 			return
+		}
+
+		// Pause proxy generation while files are being reorganised.
+		if cfg.ProxyWorker != nil {
+			cfg.ProxyWorker.Pause()
+			defer cfg.ProxyWorker.Resume()
 		}
 
 		changes, err := db.PlanRescan(cfg.DB)

--- a/internal/api/duplicates.go
+++ b/internal/api/duplicates.go
@@ -237,6 +237,73 @@ func handleBulkDeleteIdentical(cfg Config) http.HandlerFunc {
 // helpers
 // ──────────────────────────────────────────────────────────────────────────────
 
+// handleRescanDuplicates performs a full checksum-based re-scan of the archive:
+//   - Orphaned _duplicates/ entries (unique checksum, no primary) → promoted to
+//     their derived primary path.
+//   - Multiple primary-path files with the same checksum → the extras are moved
+//     into a _duplicates/ subdirectory alongside the canonical primary.
+//
+// Requires confirm=true query param as a safety guard.
+func handleRescanDuplicates(cfg Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("confirm") != "true" {
+			writeError(w, http.StatusBadRequest, "confirm=true is required")
+			return
+		}
+
+		changes, err := db.PlanRescan(cfg.DB)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "plan rescan: "+err.Error())
+			return
+		}
+
+		absRoot, _ := filepath.Abs(cfg.ArchiveRoot)
+		result := db.RescanResult{}
+
+		for _, c := range changes {
+			absOld, _ := filepath.Abs(c.OldPath)
+			absNew, _ := filepath.Abs(c.NewPath)
+
+			if !isUnderRoot(absOld, absRoot) || !isUnderRoot(absNew, absRoot) {
+				result.Errors = append(result.Errors, c.FileName+": path outside archive root")
+				continue
+			}
+
+			// Ensure destination directory exists.
+			if err := os.MkdirAll(filepath.Dir(absNew), 0755); err != nil {
+				result.Errors = append(result.Errors, c.FileName+": mkdir: "+err.Error())
+				continue
+			}
+
+			// Avoid overwriting an existing file at the destination.
+			if _, statErr := os.Stat(absNew); statErr == nil {
+				result.Errors = append(result.Errors,
+					c.FileName+": destination already exists, skipping")
+				continue
+			}
+
+			if err := os.Rename(absOld, absNew); err != nil {
+				result.Errors = append(result.Errors, c.FileName+": rename: "+err.Error())
+				continue
+			}
+
+			if err := db.UpdateArchivePath(cfg.DB, c.FileID, c.NewPath); err != nil {
+				result.Errors = append(result.Errors, c.FileName+": db update: "+err.Error())
+				continue
+			}
+
+			switch c.ChangeType {
+			case "promote":
+				result.Promoted++
+			case "new_dup":
+				result.NewDups++
+			}
+		}
+
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
 func isUnderRoot(absPath, absRoot string) bool {
 	return absPath == absRoot ||
 		len(absPath) > len(absRoot) &&

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -57,6 +57,7 @@ func NewRouter(cfg Config) http.Handler {
 		r.Route("/duplicates", func(r chi.Router) {
 			r.Get("/", handleListDuplicates(cfg))
 			r.Post("/bulk-delete-identical", readonlyGuard(cfg, handleBulkDeleteIdentical(cfg)))
+			r.Post("/rescan", readonlyGuard(cfg, handleRescanDuplicates(cfg)))
 			r.Post("/{id}/promote", readonlyGuard(cfg, handlePromoteDuplicate(cfg)))
 		})
 

--- a/internal/db/duplicates.go
+++ b/internal/db/duplicates.go
@@ -8,22 +8,46 @@ import (
 )
 
 // DuplicateGroup pairs a primary archived file with one or more duplicate
-// files that live under a `_duplicates/` sub-path with the same base name.
+// files that share the same content (by checksum) or the same file_name under
+// a `_duplicates/` path when no checksum is available.
 type DuplicateGroup struct {
 	FileName   string  `json:"file_name"`
-	Primary    *File   `json:"primary"`    // nil when the primary has been deleted
+	Checksum   string  `json:"checksum,omitempty"`
+	Primary    *File   `json:"primary"`    // nil when the primary has been deleted/moved
 	Duplicates []*File `json:"duplicates"` // always ≥ 1
 }
 
-// GetDuplicateGroups returns all duplicate groups.
-// Each group contains the non-duplicate primary (if it exists) and all
-// _duplicates counterparts matched by file_name.
+// RescanResult summarises the changes made during a checksum re-scan.
+type RescanResult struct {
+	Promoted int      `json:"promoted"`  // orphaned _duplicates/ files promoted to primary path
+	NewDups  int      `json:"new_dups"`  // previously-unlabelled files moved into _duplicates/
+	Errors   []string `json:"errors,omitempty"`
+}
+
+// RescanChange describes a single change the rescan wants to make.
+type RescanChange struct {
+	FileID      int64
+	OldPath     string
+	NewPath     string
+	FileName    string
+	ChangeType  string // "promote" | "new_dup"
+}
+
+
+// GetDuplicateGroups returns all duplicate groups using checksum-first grouping.
+// Files with a non-empty checksum are grouped by content so cross-name duplicates
+// are surfaced. Files without a checksum fall back to file_name grouping.
+// Each group contains the non-duplicate primary (if present) and all
+// _duplicates counterparts.
 func GetDuplicateGroups(database *sql.DB) ([]DuplicateGroup, error) {
 	rows, err := database.Query(`
-		SELECT id, original_path, archive_path, file_name, size, checksum, mod_time
+		SELECT id, original_path, archive_path, file_name, size,
+		       COALESCE(checksum,'') AS checksum, mod_time,
+		       COALESCE(proxy_path,'') AS proxy_path,
+		       COALESCE(proxy_status,'') AS proxy_status
 		FROM file_registry
 		WHERE trashed_at IS NULL
-		ORDER BY file_name, archive_path
+		ORDER BY id ASC
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("duplicate groups query: %w", err)
@@ -31,58 +55,112 @@ func GetDuplicateGroups(database *sql.DB) ([]DuplicateGroup, error) {
 	defer rows.Close()
 
 	type fileRow struct {
-		file  File
-		isDup bool
+		file File
 	}
 
-	// Collect all files, bucketed by file_name.
-	byName := make(map[string][]fileRow)
-	var nameOrder []string
-	seen := make(map[string]bool)
-
+	var allFiles []File
 	for rows.Next() {
 		var f File
 		var modTimeStr string
 		if err := rows.Scan(
 			&f.ID, &f.OriginalPath, &f.ArchivePath,
 			&f.FileName, &f.Size, &f.Checksum, &modTimeStr,
+			&f.ProxyPath, &f.ProxyStatus,
 		); err != nil {
 			return nil, err
 		}
 		f.ModTime = parseTime(modTimeStr)
 		f.Extension = fileExtension(f.FileName)
 		f.IsDuplicate = isDuplicate(f.ArchivePath)
-
-		if !seen[f.FileName] {
-			seen[f.FileName] = true
-			nameOrder = append(nameOrder, f.FileName)
-		}
-		byName[f.FileName] = append(byName[f.FileName], fileRow{file: f, isDup: f.IsDuplicate})
+		allFiles = append(allFiles, f)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 
-	// Build groups: only include names that have at least one duplicate.
+	// ── Group by checksum (content-first) ────────────────────────────────────
+	byChecksum := make(map[string][]File)
+	var checksumOrder []string
+	seenChecksum := make(map[string]bool)
+
+	var noChecksumFiles []File // fall back to name-based grouping
+
+	for _, f := range allFiles {
+		if f.Checksum == "" {
+			noChecksumFiles = append(noChecksumFiles, f)
+			continue
+		}
+		if !seenChecksum[f.Checksum] {
+			seenChecksum[f.Checksum] = true
+			checksumOrder = append(checksumOrder, f.Checksum)
+		}
+		byChecksum[f.Checksum] = append(byChecksum[f.Checksum], f)
+	}
+
 	var groups []DuplicateGroup
-	for _, name := range nameOrder {
-		rows := byName[name]
+
+	// Checksum-based groups.
+	for _, ck := range checksumOrder {
+		files := byChecksum[ck]
+
 		var primary *File
 		var dups []*File
-
-		for i := range rows {
-			r := &rows[i]
-			if r.isDup {
-				cp := r.file
+		for i := range files {
+			f := &files[i]
+			if f.IsDuplicate {
+				cp := *f
 				dups = append(dups, &cp)
 			} else if primary == nil {
-				cp := r.file
+				cp := *f
 				primary = &cp
 			}
 		}
-
 		if len(dups) == 0 {
-			continue // no duplicate entries for this name
+			continue // no duplicate entries for this checksum
+		}
+
+		name := ""
+		if primary != nil {
+			name = primary.FileName
+		} else if len(dups) > 0 {
+			name = dups[0].FileName
+		}
+
+		groups = append(groups, DuplicateGroup{
+			FileName:   name,
+			Checksum:   ck,
+			Primary:    primary,
+			Duplicates: dups,
+		})
+	}
+
+	// Fall-back: file_name grouping for files without checksums.
+	byName := make(map[string][]File)
+	var nameOrder []string
+	seenName := make(map[string]bool)
+	for _, f := range noChecksumFiles {
+		if !seenName[f.FileName] {
+			seenName[f.FileName] = true
+			nameOrder = append(nameOrder, f.FileName)
+		}
+		byName[f.FileName] = append(byName[f.FileName], f)
+	}
+	for _, name := range nameOrder {
+		files := byName[name]
+		var primary *File
+		var dups []*File
+		for i := range files {
+			f := &files[i]
+			if f.IsDuplicate {
+				cp := *f
+				dups = append(dups, &cp)
+			} else if primary == nil {
+				cp := *f
+				primary = &cp
+			}
+		}
+		if len(dups) == 0 {
+			continue
 		}
 		groups = append(groups, DuplicateGroup{
 			FileName:   name,
@@ -90,8 +168,100 @@ func GetDuplicateGroups(database *sql.DB) ([]DuplicateGroup, error) {
 			Duplicates: dups,
 		})
 	}
+
 	return groups, nil
 }
+
+// PlanRescan analyses the file registry by checksum and returns the list of
+// changes needed to normalise duplicate state:
+//
+//   - "promote": a file currently in _duplicates/ is the only copy → move to
+//     its derived primary path.
+//   - "new_dup": two or more primary-path files share a checksum → all but the
+//     first (lowest ID) should move into a _duplicates/ sub-directory.
+func PlanRescan(database *sql.DB) ([]RescanChange, error) {
+	rows, err := database.Query(`
+		SELECT id, archive_path, file_name, COALESCE(checksum,'') AS checksum
+		FROM file_registry
+		WHERE trashed_at IS NULL AND checksum != ''
+		ORDER BY id ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("rescan query: %w", err)
+	}
+	defer rows.Close()
+
+	type entry struct {
+		ID          int64
+		ArchivePath string
+		FileName    string
+		Checksum    string
+		IsDup       bool
+	}
+
+	byChecksum := make(map[string][]entry)
+	for rows.Next() {
+		var e entry
+		if err := rows.Scan(&e.ID, &e.ArchivePath, &e.FileName, &e.Checksum); err != nil {
+			return nil, err
+		}
+		e.IsDup = isDuplicate(e.ArchivePath)
+		byChecksum[e.Checksum] = append(byChecksum[e.Checksum], e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	var changes []RescanChange
+
+	for _, files := range byChecksum {
+		var primaries, dups []entry
+		for _, f := range files {
+			if f.IsDup {
+				dups = append(dups, f)
+			} else {
+				primaries = append(primaries, f)
+			}
+		}
+
+		switch {
+		case len(primaries) == 0 && len(dups) == 1:
+			// Orphaned duplicate — unique content, no primary: promote.
+			d := dups[0]
+			newPath := DerivePrimaryPath(d.ArchivePath)
+			changes = append(changes, RescanChange{
+				FileID: d.ID, OldPath: d.ArchivePath, NewPath: newPath,
+				FileName: d.FileName, ChangeType: "promote",
+			})
+
+		case len(primaries) > 1:
+			// Multiple primaries with same checksum — keep first, move rest to _dups.
+			canonical := primaries[0]
+			canonicalDir := filepath.Dir(canonical.ArchivePath)
+			for _, extra := range primaries[1:] {
+				dupDir := filepath.Join(canonicalDir, "_duplicates")
+				newPath := filepath.Join(dupDir, extra.FileName)
+				changes = append(changes, RescanChange{
+					FileID: extra.ID, OldPath: extra.ArchivePath, NewPath: newPath,
+					FileName: extra.FileName, ChangeType: "new_dup",
+				})
+			}
+		}
+	}
+	return changes, nil
+}
+
+// UpdateArchivePath updates the archive_path for a single file registry record.
+func UpdateArchivePath(database *sql.DB, id int64, newPath string) error {
+	_, err := database.Exec(
+		`UPDATE file_registry SET archive_path = ? WHERE id = ?`, newPath, id,
+	)
+	if err != nil {
+		return fmt.Errorf("update archive path id=%d: %w", id, err)
+	}
+	return nil
+}
+
 
 // DeleteFileRecord removes a file from the file_registry table.
 // Actual disk deletion must be performed by the caller before this call.

--- a/internal/db/duplicates.go
+++ b/internal/db/duplicates.go
@@ -172,16 +172,18 @@ func GetDuplicateGroups(database *sql.DB) ([]DuplicateGroup, error) {
 	return groups, nil
 }
 
-// PlanRescan analyses the file registry by checksum and returns the list of
-// changes needed to normalise duplicate state:
+// PlanRescan analyses the file registry and returns the list of changes needed
+// to normalise duplicate state. Files are matched by a three-way fingerprint:
+// checksum + file size + extension — same content regardless of filename.
 //
-//   - "promote": a file currently in _duplicates/ is the only copy → move to
-//     its derived primary path.
-//   - "new_dup": two or more primary-path files share a checksum → all but the
-//     first (lowest ID) should move into a _duplicates/ sub-directory.
+//   - "promote": a file in _duplicates/ is the only copy → move to primary path.
+//   - "new_dup":  two or more primary-path files share a fingerprint → keep the
+//     first (lowest ID), move the rest into a _duplicates/ sub-directory.
 func PlanRescan(database *sql.DB) ([]RescanChange, error) {
 	rows, err := database.Query(`
-		SELECT id, archive_path, file_name, COALESCE(checksum,'') AS checksum
+		SELECT id, archive_path, file_name,
+		       COALESCE(checksum,'') AS checksum,
+		       COALESCE(size, 0)     AS size
 		FROM file_registry
 		WHERE trashed_at IS NULL AND checksum != ''
 		ORDER BY id ASC
@@ -196,17 +198,24 @@ func PlanRescan(database *sql.DB) ([]RescanChange, error) {
 		ArchivePath string
 		FileName    string
 		Checksum    string
+		Size        int64
+		Ext         string
 		IsDup       bool
 	}
 
-	byChecksum := make(map[string][]entry)
+	// Group by composite key: checksum + size + extension.
+	type key struct{ checksum string; size int64; ext string }
+	byKey := make(map[key][]entry)
+
 	for rows.Next() {
 		var e entry
-		if err := rows.Scan(&e.ID, &e.ArchivePath, &e.FileName, &e.Checksum); err != nil {
+		if err := rows.Scan(&e.ID, &e.ArchivePath, &e.FileName, &e.Checksum, &e.Size); err != nil {
 			return nil, err
 		}
+		e.Ext = strings.ToLower(strings.TrimPrefix(filepath.Ext(e.FileName), "."))
 		e.IsDup = isDuplicate(e.ArchivePath)
-		byChecksum[e.Checksum] = append(byChecksum[e.Checksum], e)
+		k := key{e.Checksum, e.Size, e.Ext}
+		byKey[k] = append(byKey[k], e)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -214,7 +223,7 @@ func PlanRescan(database *sql.DB) ([]RescanChange, error) {
 
 	var changes []RescanChange
 
-	for _, files := range byChecksum {
+	for _, files := range byKey {
 		var primaries, dups []entry
 		for _, f := range files {
 			if f.IsDup {
@@ -225,27 +234,29 @@ func PlanRescan(database *sql.DB) ([]RescanChange, error) {
 		}
 
 		switch {
-		case len(primaries) == 0 && len(dups) == 1:
-			// Orphaned duplicate — unique content, no primary: promote.
-			d := dups[0]
-			newPath := DerivePrimaryPath(d.ArchivePath)
+		case len(primaries) == 0 && len(dups) >= 1:
+			// All copies are in _duplicates/ — promote the first (lowest ID).
+			canonical := dups[0]
+			newPath := DerivePrimaryPath(canonical.ArchivePath)
 			changes = append(changes, RescanChange{
-				FileID: d.ID, OldPath: d.ArchivePath, NewPath: newPath,
-				FileName: d.FileName, ChangeType: "promote",
+				FileID: canonical.ID, OldPath: canonical.ArchivePath, NewPath: newPath,
+				FileName: canonical.FileName, ChangeType: "promote",
 			})
+			// Any remaining orphaned dups stay as _duplicates/ (they have a new canonical now).
 
 		case len(primaries) > 1:
-			// Multiple primaries with same checksum — keep first, move rest to _dups.
+			// Multiple primary-path copies — keep the first (lowest ID), move the rest.
 			canonical := primaries[0]
 			canonicalDir := filepath.Dir(canonical.ArchivePath)
+			dupDir := filepath.Join(canonicalDir, "_duplicates")
 			for _, extra := range primaries[1:] {
-				dupDir := filepath.Join(canonicalDir, "_duplicates")
 				newPath := filepath.Join(dupDir, extra.FileName)
 				changes = append(changes, RescanChange{
 					FileID: extra.ID, OldPath: extra.ArchivePath, NewPath: newPath,
 					FileName: extra.FileName, ChangeType: "new_dup",
 				})
 			}
+		// case len(primaries) == 1: already correct, no action needed.
 		}
 	}
 	return changes, nil

--- a/internal/webui/web/index.html
+++ b/internal/webui/web/index.html
@@ -1066,12 +1066,16 @@
                   <template x-if="g.primary">
                     <div class="space-y-2">
                       <!-- Thumbnail/preview -->
-                      <template x-if="isImageExt(fileExt(g.file_name))">
-                        <img :src="thumbnailURL(g.primary.id)" :alt="g.file_name"
+                      <template x-if="isImageExt(fileExt(g.primary.file_name || g.file_name))">
+                        <img :src="thumbnailURL(g.primary.id)" :alt="g.primary.file_name"
                              class="w-32 h-32 object-cover rounded-lg border border-gray-200 mb-3"
                              @error="$event.target.style.display='none'" />
                       </template>
                       <div class="space-y-1 text-sm">
+                        <div class="flex justify-between">
+                          <span class="text-gray-500">Name</span>
+                          <span class="font-mono text-xs text-gray-700 truncate max-w-40" x-text="g.primary.file_name"></span>
+                        </div>
                         <div class="flex justify-between">
                           <span class="text-gray-500">Size</span>
                           <span class="font-mono text-gray-700" x-text="formatBytes(g.primary.size)"></span>
@@ -1088,6 +1092,17 @@
                           <p class="text-xs text-gray-400 font-mono break-all" x-text="g.primary.archive_path"></p>
                         </div>
                       </div>
+                      <!-- Preview button -->
+                      <button @click="openViewerFromDup(g.primary)"
+                        class="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-gray-100 hover:bg-gray-200 text-gray-700 text-xs font-medium transition-colors">
+                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+                        </svg>
+                        Preview
+                      </button>
+                    </div>
+                  </template>
                     </div>
                   </template>
                   <template x-if="!g.primary">
@@ -1106,12 +1121,16 @@
                   <template x-for="(dup, di) in g.duplicates" :key="dup.id">
                     <div class="space-y-2" :class="di > 0 ? 'mt-4 pt-4 border-t border-gray-100' : ''">
                       <!-- Thumbnail/preview -->
-                      <template x-if="isImageExt(fileExt(g.file_name))">
-                        <img :src="thumbnailURL(dup.id)" :alt="g.file_name"
+                      <template x-if="isImageExt(fileExt(dup.file_name || g.file_name))">
+                        <img :src="thumbnailURL(dup.id)" :alt="dup.file_name"
                              class="w-32 h-32 object-cover rounded-lg border border-gray-200 mb-3"
                              @error="$event.target.style.display='none'" />
                       </template>
                       <div class="space-y-1 text-sm">
+                        <div class="flex justify-between">
+                          <span class="text-gray-500">Name</span>
+                          <span class="font-mono text-xs text-gray-700 truncate max-w-40" x-text="dup.file_name"></span>
+                        </div>
                         <div class="flex justify-between">
                           <span class="text-gray-500">Size</span>
                           <span class="font-mono text-gray-700" x-text="formatBytes(dup.size)"></span>
@@ -1131,6 +1150,14 @@
 
                       <!-- Actions -->
                       <div class="flex flex-wrap gap-2 pt-3 border-t border-gray-100">
+                        <button @click="openViewerFromDup(dup)"
+                          class="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-gray-100 hover:bg-gray-200 text-gray-700 text-xs font-medium transition-colors">
+                          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+                          </svg>
+                          Preview
+                        </button>
                         <button @click="confirmDeleteDup(dup, g)"
                           class="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-red-50 hover:bg-red-100 text-red-700 text-xs font-medium transition-colors">
                           <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/internal/webui/web/index.html
+++ b/internal/webui/web/index.html
@@ -943,16 +943,29 @@
       <div x-show="page === 'duplicates'" class="p-6 max-w-6xl mx-auto">
 
         <!-- Header row -->
-        <div class="flex items-center justify-between mb-6">
+        <div class="flex flex-wrap items-start justify-between gap-3 mb-4">
           <div>
             <h1 class="text-xl font-semibold text-gray-800">Duplicate Files</h1>
             <p class="text-sm text-gray-500 mt-0.5"
                x-text="dupGroups.length + ' group' + (dupGroups.length === 1 ? '' : 's') + ' found'"></p>
           </div>
-          <div class="flex gap-2">
+          <div class="flex flex-wrap gap-2">
             <button @click="refreshDuplicates()"
               class="px-3 py-2 rounded-lg border border-gray-300 hover:bg-gray-100 text-sm transition-colors">
               ↺ Refresh
+            </button>
+            <button @click="confirmRescan()"
+              :disabled="dupRescanLoading"
+              class="flex items-center gap-1.5 px-3 py-2 rounded-lg border border-blue-300 bg-blue-50 hover:bg-blue-100 text-blue-700 text-sm font-medium disabled:opacity-40 transition-colors">
+              <svg x-show="!dupRescanLoading" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+              </svg>
+              <svg x-show="dupRescanLoading" class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/>
+              </svg>
+              Re-scan
             </button>
             <button @click="confirmBulkDelete()"
               :disabled="identicalCount === 0"
@@ -966,6 +979,34 @@
                 class="bg-white/20 px-1.5 rounded text-xs" x-text="'(' + identicalCount + ')'"></span>
             </button>
           </div>
+        </div>
+
+        <!-- Re-scan result banner -->
+        <div x-show="dupRescanResult" x-transition
+             class="mb-4 px-4 py-3 rounded-xl border border-blue-200 bg-blue-50 text-sm text-blue-800 flex items-start gap-3">
+          <svg class="w-5 h-5 flex-shrink-0 mt-0.5 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+          </svg>
+          <div class="flex-1">
+            <p class="font-medium">Re-scan complete</p>
+            <p class="mt-0.5">
+              <span x-text="dupRescanResult?.promoted ?? 0"></span> orphaned duplicate(s) promoted to primary path ·
+              <span x-text="dupRescanResult?.new_dups ?? 0"></span> new duplicate(s) moved to _duplicates/
+            </p>
+            <template x-if="dupRescanResult?.errors?.length > 0">
+              <ul class="mt-1 text-xs text-red-600 list-disc list-inside">
+                <template x-for="e in dupRescanResult.errors" :key="e">
+                  <li x-text="e"></li>
+                </template>
+              </ul>
+            </template>
+          </div>
+          <button @click="dupRescanResult = null" class="text-blue-400 hover:text-blue-600 flex-shrink-0">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+            </svg>
+          </button>
         </div>
 
         <!-- Loading / empty states -->
@@ -1098,16 +1139,14 @@
                           </svg>
                           Delete duplicate
                         </button>
-                        <template x-if="g.primary">
-                          <button @click="confirmPromote(dup, g)"
-                            class="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-blue-50 hover:bg-blue-100 text-blue-700 text-xs font-medium transition-colors">
-                            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                d="M5 10l7-7m0 0l7 7m-7-7v18"/>
-                            </svg>
-                            Promote (replace primary)
-                          </button>
-                        </template>
+                        <button @click="confirmPromote(dup, g)"
+                          class="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-blue-50 hover:bg-blue-100 text-blue-700 text-xs font-medium transition-colors">
+                          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                              d="M5 10l7-7m0 0l7 7m-7-7v18"/>
+                          </svg>
+                          <span x-text="g.primary ? 'Promote (replace primary)' : 'Promote to primary'"></span>
+                        </button>
                       </div>
                     </div>
                   </template>

--- a/internal/webui/web/static/app.js
+++ b/internal/webui/web/static/app.js
@@ -112,6 +112,8 @@ document.addEventListener('alpine:init', () => {
     dupGroups:          [],
     dupLoading:         false,
     dupDismissed:       {},   // { groupIndex: true }
+    dupRescanLoading:   false,
+    dupRescanResult:    null,  // { promoted, new_dups, errors }
     dupConfirmOpen:     false,
     dupConfirmTitle:    '',
     dupConfirmMessage:  '',
@@ -848,16 +850,44 @@ document.addEventListener('alpine:init', () => {
     },
 
     confirmPromote(dup, group) {
-      this.dupConfirmTitle   = 'Promote duplicate to primary?';
-      this.dupConfirmMessage = `The duplicate will be moved to the primary location. The existing primary will be removed.`;
+      const hasPrimary = !!group.primary;
+      this.dupConfirmTitle   = hasPrimary ? 'Promote duplicate to primary?' : 'Promote orphaned duplicate?';
+      this.dupConfirmMessage = hasPrimary
+        ? `The duplicate will be moved to the primary location. The existing primary will be removed.`
+        : `No primary file was found. The duplicate will be moved to its derived primary path (the _duplicates/ segment will be removed from its path).`;
       this.dupConfirmPath    = dup.archive_path;
       this.dupConfirmAction  = 'Promote';
       this.dupConfirmDanger  = false;
       this._dupConfirmFn     = async () => {
-        await this._doPromote(dup.id, group.primary ? group.primary.id : null);
+        await this._doPromote(dup.id, hasPrimary ? group.primary.id : null);
         await this.loadDuplicates();
       };
       this.dupConfirmOpen    = true;
+    },
+
+    confirmRescan() {
+      this.dupConfirmTitle   = 'Re-scan for duplicates?';
+      this.dupConfirmMessage = `This performs a full checksum-based re-scan:\n• Orphaned duplicates (only copy, in _duplicates/) are promoted to their primary path.\n• Files sharing a checksum that are not yet in _duplicates/ will be moved there.\n\nFiles are moved on disk. This cannot be undone.`;
+      this.dupConfirmPath    = '';
+      this.dupConfirmAction  = 'Re-scan';
+      this.dupConfirmDanger  = false;
+      this._dupConfirmFn     = async () => {
+        this.dupRescanLoading = true;
+        this.dupRescanResult  = null;
+        try {
+          const res = await fetch('/api/duplicates/rescan?confirm=true', { method: 'POST' });
+          const j   = await res.json();
+          if (!res.ok) { this.showToast('Re-scan error: ' + (j.error || res.status)); return; }
+          this.dupRescanResult = j;
+          await this.loadDuplicates();
+          this.loadStats();
+        } catch(e) {
+          this.showToast('Re-scan failed: ' + e.message);
+        } finally {
+          this.dupRescanLoading = false;
+        }
+      };
+      this.dupConfirmOpen = true;
     },
 
     confirmBulkDelete() {

--- a/internal/webui/web/static/app.js
+++ b/internal/webui/web/static/app.js
@@ -729,6 +729,13 @@ document.addEventListener('alpine:init', () => {
       this.openViewer(file);
     },
 
+    // Opens the viewer for a file in the Duplicates tab.
+    // viewerIndex = -1 disables prev/next navigation (no surrounding list).
+    openViewerFromDup(file) {
+      this.viewerIndex = -1;
+      this.openViewer(file);
+    },
+
     highlight(text, query) {
       if (!query || !text) return this._escapeHTML(text || '');
       const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Re-scan** action to the Duplicates page to reorganise and normalise duplicate files.
  * Displays rescan results, including promoted files, newly moved duplicates, and any errors.
  * Added media preview buttons for primary and duplicate files.
  * Duplicate grouping now uses file checksums where available, with filename fallback.
  * Promote actions are available for all duplicate entries, including groups without a current primary.

* **Bug Fixes**
  * Improved duplicate detection and handling of orphaned or repeated primary files.
  * Prevented rescan operations while the server is in read-only mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->