### PR TITLE
Duplicates tab: redesign as proper side-by-side comparison UI

### DIFF
--- a/internal/webui/web/index.html
+++ b/internal/webui/web/index.html
@@ -1033,152 +1033,162 @@
             <div class="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
 
               <!-- Group header -->
-              <div class="flex items-center justify-between px-5 py-3 bg-gray-50 border-b border-gray-200">
-                <div class="flex items-center gap-2">
-                  <span class="w-2 h-2 rounded-full"
+              <div class="flex items-center justify-between gap-3 px-5 py-3 bg-gray-50 border-b border-gray-200">
+                <div class="flex items-center gap-2 min-w-0">
+                  <span class="w-2 h-2 rounded-full flex-shrink-0"
                         :style="'background:' + extColor(fileExt(g.file_name))"></span>
-                  <span class="font-medium text-gray-800 text-sm" x-text="g.file_name"></span>
-                  <template x-for="dup in g.duplicates">
-                    <span class="ml-1 px-2 py-0.5 rounded-full text-xs font-medium"
-                          :class="dupIsIdentical(g, dup)
-                            ? 'bg-yellow-100 text-yellow-700'
-                            : 'bg-red-100 text-red-700'"
-                          x-text="dupIsIdentical(g, dup) ? 'Identical' : 'Different content'">
-                    </span>
-                  </template>
+                  <span class="font-medium text-gray-800 text-sm truncate" x-text="g.file_name"></span>
+                  <span class="flex-shrink-0 px-2 py-0.5 rounded-full text-xs font-medium"
+                        :class="g.duplicates.some(d => dupIsIdentical(g,d)) ? 'bg-yellow-100 text-yellow-700' : 'bg-orange-100 text-orange-700'"
+                        x-text="g.duplicates.some(d => dupIsIdentical(g,d)) ? 'Identical content' : 'Similar'">
+                  </span>
+                  <span class="flex-shrink-0 text-xs text-gray-400"
+                        x-text="g.duplicates.length + ' copy' + (g.duplicates.length === 1 ? '' : 's')">
+                  </span>
                 </div>
                 <button @click="dismissGroup(gi)"
-                  class="text-xs text-gray-400 hover:text-gray-600 px-2 py-1 rounded hover:bg-gray-100 transition-colors"
+                  class="flex-shrink-0 text-xs text-gray-400 hover:text-gray-600 px-2 py-1 rounded hover:bg-gray-100 transition-colors"
                   title="Keep both — hide from this view">
                   Keep both
                 </button>
               </div>
 
-              <!-- Side-by-side comparison -->
-              <div class="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-gray-100">
+              <!-- One comparison panel per duplicate -->
+              <template x-for="(dup, di) in g.duplicates" :key="dup.id">
+                <div :class="di > 0 ? 'border-t-2 border-dashed border-gray-200' : ''">
 
-                <!-- Primary -->
-                <div class="p-5">
-                  <div class="flex items-center gap-2 mb-3">
-                    <span class="px-2 py-0.5 bg-blue-100 text-blue-700 rounded text-xs font-semibold">Primary</span>
-                    <span class="text-xs text-gray-400">main archive copy</span>
-                  </div>
-                  <template x-if="g.primary">
-                    <div class="space-y-2">
-                      <!-- Thumbnail/preview -->
-                      <template x-if="isImageExt(fileExt(g.primary.file_name || g.file_name))">
-                        <img :src="thumbnailURL(g.primary.id)" :alt="g.primary.file_name"
-                             class="w-32 h-32 object-cover rounded-lg border border-gray-200 mb-3"
-                             @error="$event.target.style.display='none'" />
-                      </template>
-                      <div class="space-y-1 text-sm">
-                        <div class="flex justify-between">
-                          <span class="text-gray-500">Name</span>
-                          <span class="font-mono text-xs text-gray-700 truncate max-w-40" x-text="g.primary.file_name"></span>
-                        </div>
-                        <div class="flex justify-between">
-                          <span class="text-gray-500">Size</span>
-                          <span class="font-mono text-gray-700" x-text="formatBytes(g.primary.size)"></span>
-                        </div>
-                        <div class="flex justify-between">
-                          <span class="text-gray-500">Modified</span>
-                          <span class="text-gray-700" x-text="formatDate(g.primary.mod_time)"></span>
-                        </div>
-                        <div class="flex gap-1">
-                          <span class="text-gray-500 flex-shrink-0">Checksum</span>
-                          <span class="font-mono text-xs text-gray-400 truncate" x-text="g.primary.checksum || '—'"></span>
-                        </div>
-                        <div class="pt-1">
-                          <p class="text-xs text-gray-400 font-mono break-all" x-text="g.primary.archive_path"></p>
-                        </div>
-                      </div>
-                      <!-- Preview button -->
-                      <button @click="openViewerFromDup(g.primary)"
-                        class="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-gray-100 hover:bg-gray-200 text-gray-700 text-xs font-medium transition-colors">
-                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
-                        </svg>
-                        Preview
-                      </button>
-                    </div>
-                  </template>
-                    </div>
-                  </template>
-                  <template x-if="!g.primary">
-                    <div class="text-sm text-gray-400 italic">Primary file not found in registry</div>
-                  </template>
-                </div>
+                  <!-- Comparison grid: primary | vs | duplicate -->
+                  <div class="grid grid-cols-1 md:grid-cols-[1fr_32px_1fr]">
 
-                <!-- Duplicates -->
-                <div class="p-5">
-                  <div class="flex items-center gap-2 mb-3">
-                    <span class="px-2 py-0.5 bg-yellow-100 text-yellow-700 rounded text-xs font-semibold">
-                      Duplicate<template x-if="g.duplicates.length > 1">s</template>
-                    </span>
-                    <span class="text-xs text-gray-400">in _duplicates/</span>
-                  </div>
-                  <template x-for="(dup, di) in g.duplicates" :key="dup.id">
-                    <div class="space-y-2" :class="di > 0 ? 'mt-4 pt-4 border-t border-gray-100' : ''">
-                      <!-- Thumbnail/preview -->
-                      <template x-if="isImageExt(fileExt(dup.file_name || g.file_name))">
-                        <img :src="thumbnailURL(dup.id)" :alt="dup.file_name"
-                             class="w-32 h-32 object-cover rounded-lg border border-gray-200 mb-3"
-                             @error="$event.target.style.display='none'" />
-                      </template>
-                      <div class="space-y-1 text-sm">
-                        <div class="flex justify-between">
-                          <span class="text-gray-500">Name</span>
-                          <span class="font-mono text-xs text-gray-700 truncate max-w-40" x-text="dup.file_name"></span>
-                        </div>
-                        <div class="flex justify-between">
-                          <span class="text-gray-500">Size</span>
-                          <span class="font-mono text-gray-700" x-text="formatBytes(dup.size)"></span>
-                        </div>
-                        <div class="flex justify-between">
-                          <span class="text-gray-500">Modified</span>
-                          <span class="text-gray-700" x-text="formatDate(dup.mod_time)"></span>
-                        </div>
-                        <div class="flex gap-1">
-                          <span class="text-gray-500 flex-shrink-0">Checksum</span>
-                          <span class="font-mono text-xs text-gray-400 truncate" x-text="dup.checksum || '—'"></span>
-                        </div>
-                        <div class="pt-1">
-                          <p class="text-xs text-gray-400 font-mono break-all" x-text="dup.archive_path"></p>
-                        </div>
+                    <!-- ── PRIMARY column ── -->
+                    <div class="p-4 md:p-5 flex flex-col gap-3">
+                      <div class="flex items-center gap-2">
+                        <span class="px-2 py-0.5 bg-blue-100 text-blue-700 rounded text-xs font-semibold">✓ Primary</span>
+                        <span class="text-xs text-gray-400">canonical copy</span>
                       </div>
 
-                      <!-- Actions -->
-                      <div class="flex flex-wrap gap-2 pt-3 border-t border-gray-100">
-                        <button @click="openViewerFromDup(dup)"
-                          class="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-gray-100 hover:bg-gray-200 text-gray-700 text-xs font-medium transition-colors">
-                          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <template x-if="g.primary">
+                        <div class="flex flex-col gap-3">
+                          <!-- Clickable thumbnail -->
+                          <button @click="openViewerFromDup(g.primary)"
+                            class="relative w-full rounded-xl overflow-hidden bg-gray-100 aspect-video group border border-gray-200 hover:border-blue-300 transition-colors">
+                            <img :src="thumbnailURL(g.primary.id)"
+                                 class="w-full h-full object-cover"
+                                 @error="$event.target.style.display='none'" />
+                            <!-- proxy badge -->
+                            <template x-if="g.primary.proxy_status === 'done'">
+                              <span class="absolute top-2 left-2 px-1.5 py-0.5 bg-black/60 text-white text-[10px] rounded font-medium">Proxy</span>
+                            </template>
+                            <!-- hover overlay -->
+                            <div class="absolute inset-0 flex items-center justify-center bg-black/0 group-hover:bg-black/25 transition-colors">
+                              <svg class="w-8 h-8 text-white opacity-0 group-hover:opacity-100 transition-opacity drop-shadow"
+                                   fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+                              </svg>
+                            </div>
+                          </button>
+                          <!-- Metadata -->
+                          <div class="space-y-1 text-xs">
+                            <p class="font-medium text-gray-700 truncate" x-text="g.primary.file_name"></p>
+                            <div class="flex items-center justify-between text-gray-500">
+                              <span x-text="formatBytes(g.primary.size)"></span>
+                              <span x-text="formatDate(g.primary.mod_time)"></span>
+                            </div>
+                            <p class="font-mono text-gray-400 break-all leading-tight" x-text="g.primary.archive_path"></p>
+                          </div>
+                          <!-- Action: keep primary → delete the duplicate -->
+                          <button @click="confirmDeleteDup(dup, g)"
+                            class="flex items-center justify-center gap-1.5 w-full px-3 py-2 rounded-lg bg-green-600 hover:bg-green-500 text-white text-xs font-semibold transition-colors">
+                            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                            </svg>
+                            Keep this — delete duplicate
+                          </button>
+                        </div>
+                      </template>
+
+                      <template x-if="!g.primary">
+                        <div class="rounded-xl bg-gray-50 border border-dashed border-gray-200 aspect-video flex items-center justify-center">
+                          <p class="text-sm text-gray-400 italic text-center px-4">Primary not found in registry</p>
+                        </div>
+                      </template>
+                    </div>
+
+                    <!-- ── VS divider ── -->
+                    <div class="hidden md:flex flex-col items-center justify-center py-4 gap-0">
+                      <div class="flex-1 w-px bg-gray-200"></div>
+                      <span class="text-[10px] font-extrabold text-gray-400 tracking-widest py-2">VS</span>
+                      <div class="flex-1 w-px bg-gray-200"></div>
+                    </div>
+                    <!-- Mobile VS separator -->
+                    <div class="md:hidden flex items-center gap-3 px-5 py-1 bg-gray-50 border-y border-gray-200">
+                      <div class="flex-1 h-px bg-gray-300"></div>
+                      <span class="text-[10px] font-extrabold text-gray-400 tracking-widest">VS</span>
+                      <div class="flex-1 h-px bg-gray-300"></div>
+                    </div>
+
+                    <!-- ── DUPLICATE column ── -->
+                    <div class="p-4 md:p-5 flex flex-col gap-3">
+                      <div class="flex items-center gap-2">
+                        <span class="px-2 py-0.5 rounded text-xs font-semibold"
+                              :class="dupIsIdentical(g, dup) ? 'bg-yellow-100 text-yellow-700' : 'bg-red-100 text-red-700'"
+                              x-text="dupIsIdentical(g, dup) ? 'Identical' : 'Duplicate'"></span>
+                        <span class="text-xs text-gray-400" x-text="'copy ' + (di + 1) + ' of ' + g.duplicates.length"></span>
+                      </div>
+
+                      <!-- Clickable thumbnail -->
+                      <button @click="openViewerFromDup(dup)"
+                        class="relative w-full rounded-xl overflow-hidden bg-gray-100 aspect-video group border border-gray-200 hover:border-blue-300 transition-colors">
+                        <img :src="thumbnailURL(dup.id)"
+                             class="w-full h-full object-cover"
+                             @error="$event.target.style.display='none'" />
+                        <template x-if="dup.proxy_status === 'done'">
+                          <span class="absolute top-2 left-2 px-1.5 py-0.5 bg-black/60 text-white text-[10px] rounded font-medium">Proxy</span>
+                        </template>
+                        <div class="absolute inset-0 flex items-center justify-center bg-black/0 group-hover:bg-black/25 transition-colors">
+                          <svg class="w-8 h-8 text-white opacity-0 group-hover:opacity-100 transition-opacity drop-shadow"
+                               fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                               d="M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
                           </svg>
-                          Preview
+                        </div>
+                      </button>
+
+                      <!-- Metadata -->
+                      <div class="space-y-1 text-xs">
+                        <p class="font-medium text-gray-700 truncate" x-text="dup.file_name"></p>
+                        <div class="flex items-center justify-between text-gray-500">
+                          <span x-text="formatBytes(dup.size)"></span>
+                          <span x-text="formatDate(dup.mod_time)"></span>
+                        </div>
+                        <p class="font-mono text-gray-400 break-all leading-tight" x-text="dup.archive_path"></p>
+                      </div>
+
+                      <!-- Actions: promote OR delete -->
+                      <div class="flex flex-col gap-2">
+                        <button @click="confirmPromote(dup, g)"
+                          class="flex items-center justify-center gap-1.5 w-full px-3 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-xs font-semibold transition-colors">
+                          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18"/>
+                          </svg>
+                          <span x-text="g.primary ? 'Use this instead' : 'Make primary'"></span>
                         </button>
                         <button @click="confirmDeleteDup(dup, g)"
-                          class="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-red-50 hover:bg-red-100 text-red-700 text-xs font-medium transition-colors">
+                          class="flex items-center justify-center gap-1.5 w-full px-3 py-2 rounded-lg border border-red-200 text-red-600 hover:bg-red-50 text-xs font-medium transition-colors">
                           <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                               d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
                           </svg>
-                          Delete duplicate
-                        </button>
-                        <button @click="confirmPromote(dup, g)"
-                          class="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-blue-50 hover:bg-blue-100 text-blue-700 text-xs font-medium transition-colors">
-                          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                              d="M5 10l7-7m0 0l7 7m-7-7v18"/>
-                          </svg>
-                          <span x-text="g.primary ? 'Promote (replace primary)' : 'Promote to primary'"></span>
+                          Delete this copy
                         </button>
                       </div>
                     </div>
-                  </template>
+
+                  </div><!-- end comparison grid -->
                 </div>
-              </div><!-- end side-by-side -->
+              </template><!-- end duplicate loop -->
+
             </div><!-- end group card -->
           </template>
         </div><!-- end groups -->


### PR DESCRIPTION
Each duplicate group now shows one comparison panel per duplicate copy:

Layout:
- Primary (left) | VS divider | Duplicate (right) grid per pair
- On mobile: stacks vertically with a styled VS separator between each pair
- Multiple copies in a group produce multiple comparison rows separated by a dashed divider, keeping each pair visually self-contained

Thumbnails:
- Full-width aspect-video thumbnails (previously 128x128 thumbnail thumbnails)
- Thumbnails are clickable overlays — hovering reveals an eye icon that opens the full proxy-aware viewer (same as Files tab)
- 'Proxy' badge shown in corner when a proxy exists for that file
- Thumbnail @error hides the element gracefully

Actions redesigned for clear intent:
- Primary column: green 'Keep this — delete duplicate' button (deletes the paired duplicate copy on that row)
- Duplicate column: blue 'Use this instead' / 'Make primary' (promote) + outlined red 'Delete this copy' (trash)
- No more ambiguous 'Promote (replace primary)' label

Group header:
- 'Identical content' / 'Similar' single badge replacing per-row tags
- Copy count shown ('1 copy', '2 copies', …)
- 'Keep both' dismiss button preserved

Fixes malformed HTML from previous edit (extra </div></template> removed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a responsive comparison grid for reviewing duplicate files.
  * Added thumbnails, proxy-status indicators, file metadata, and archive paths for primary and duplicate files.
  * Added options to keep the primary, use a duplicate instead, or delete copies.
  * Added a clear placeholder when the primary file is unavailable.

* **Improvements**
  * Simplified duplicate status badges to identify groups containing identical content.
  * Removed checksum details and separate preview actions from the comparison view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->